### PR TITLE
fix(render): pin overlay format=yuv420 for ffmpeg 8.x compat (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.1 (2026-05-12)
+
+### Bug fixes
+
+- **Green color cast on output with ffmpeg 8.x** ([#4](https://github.com/ThePatriczek/playwright-recast/issues/4)) — Cursor, click-ripple, and text-highlight overlays used `overlay=...:format=auto`. With ffmpeg 8.x the overlay filter's `format=auto` heuristic selects `yuva444p` when the secondary input is RGBA, so the subsequent encode to `yuv420p` mixed the YUV planes and produced a green-tinted output (a sampled white pixel returned `RGB(127,252,126)` instead of `RGB(253,255,255)`). Pinned `format=yuv420` explicitly on all four overlay filter calls in `src/render/renderer.ts`. Output is clean white on ffmpeg 7.x and 8.x. Thanks to [@maciejdzierzek](https://github.com/maciejdzierzek) for the precise repro and root-cause analysis.
+
 ## 0.15.0 (2026-04-15)
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-recast",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "description": "Fluent pipeline library for processing Playwright traces into polished demo videos — TTS voiceover, subtitles, speed control, and zoom.",
   "license": "MIT",

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -220,7 +220,7 @@ function renderWithCursorOverlay(
     '-y',
     '-f', 'lavfi', '-i', `color=c=black@0:s=${cursorRes.width}x${cursorRes.height}:d=1:r=30,format=rgba`,
     '-i', cursorPngPath,
-    '-filter_complex', '[0:v][1:v]overlay=0:0:eof_action=repeat:format=auto[out]',
+    '-filter_complex', '[0:v][1:v]overlay=0:0:eof_action=repeat:format=yuv420[out]',
     '-map', '[out]',
     '-c:v', 'qtrle', '-pix_fmt', 'argb',
     cursorClipPath,
@@ -237,7 +237,7 @@ function renderWithCursorOverlay(
   const cursorStream = `movie='${escapedClipPath}':loop=0,setpts=N/30/TB,format=rgba[cursor]`
   const filterParts = [
     cursorStream,
-    `[0:v][cursor]overlay=x='${xExpr}':y='${yExpr}':enable='${enableExpr}':eof_action=pass:format=auto[out]`,
+    `[0:v][cursor]overlay=x='${xExpr}':y='${yExpr}':enable='${enableExpr}':eof_action=pass:format=yuv420[out]`,
   ]
 
   const outputPath = path.join(tmpDir, 'cursor-overlay.mp4')
@@ -314,7 +314,7 @@ function renderWithClickEffects(
     const ox = Math.max(0, cx - Math.round(halfSize))
     const oy = Math.max(0, cy - Math.round(halfSize))
     filterParts.push(
-      `[${prevLabel}][${rippleLabel}]overlay=${ox}:${oy}:eof_action=pass:format=auto[${outLabel}]`,
+      `[${prevLabel}][${rippleLabel}]overlay=${ox}:${oy}:eof_action=pass:format=yuv420[${outLabel}]`,
     )
     prevLabel = outLabel
   }
@@ -383,7 +383,7 @@ function renderWithHighlights(
       `movie='${escapedPath}',setpts=PTS+${timeSec}/TB,format=rgba[${hlLabel}]`,
     )
     filterParts.push(
-      `[${prevLabel}][${hlLabel}]overlay=${ox}:${oy}:eof_action=pass:format=auto[${outLabel}]`,
+      `[${prevLabel}][${hlLabel}]overlay=${ox}:${oy}:eof_action=pass:format=yuv420[${outLabel}]`,
     )
     prevLabel = outLabel
   }

--- a/tests/unit/render/overlay-format.test.ts
+++ b/tests/unit/render/overlay-format.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rendererPath = path.resolve(__dirname, '../../../src/render/renderer.ts')
+
+/**
+ * Regression guard for GitHub issue #4.
+ *
+ * ffmpeg 8.x changed the overlay filter's `format` default-resolution
+ * heuristic: with an RGBA secondary input it now selects `yuva444p`,
+ * which produces a green-tinted result once the pipeline encodes to
+ * yuv420p. Every overlay filter that mixes an RGBA cursor/ripple/highlight
+ * onto a yuv420 video must therefore pin `format=yuv420` explicitly.
+ */
+describe('overlay filter format (ffmpeg 8.x compat)', () => {
+  const source = fs.readFileSync(rendererPath, 'utf8')
+
+  it('contains no overlay filter with format=auto', () => {
+    const offenders = source
+      .split('\n')
+      .map((line, idx) => ({ line, idx: idx + 1 }))
+      .filter(({ line }) => /overlay=[^'`"]*format=auto/.test(line))
+
+    expect(offenders, `overlay=...format=auto offenders:\n${offenders.map(o => `${o.idx}: ${o.line.trim()}`).join('\n')}`).toHaveLength(0)
+  })
+
+  it('every overlay= filter pins format=yuv420', () => {
+    const overlayLines = source
+      .split('\n')
+      .map((line, idx) => ({ line, idx: idx + 1 }))
+      .filter(({ line }) => /(?<!\w)overlay=/.test(line) && !line.trim().startsWith('//') && !line.trim().startsWith('*'))
+
+    expect(overlayLines.length).toBeGreaterThan(0)
+    for (const { line, idx } of overlayLines) {
+      expect(line, `line ${idx} must pin format=yuv420: ${line.trim()}`).toMatch(/format=yuv420/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes green color cast on output when running on ffmpeg 8.x (reported in #4).
- Pins `format=yuv420` on all four `overlay=` filter calls in `src/render/renderer.ts` (cursor-clip, cursor overlay, click ripple, text highlight) — ffmpeg 8.x's `format=auto` heuristic selects `yuva444p` with RGBA secondary input, which is then mixed when the pipeline encodes to `yuv420p`.
- Adds regression guard test (`tests/unit/render/overlay-format.test.ts`) that scans `renderer.ts` and rejects any `overlay=` filter without `format=yuv420`.

## Root cause (from issue)

`overlay=...:format=auto` + ffmpeg 8.x + RGBA cursor/ripple/highlight clip → ffmpeg picks `yuva444p` as overlay output → final encode to `yuv420p` mixes YUV planes → sampled white pixel returns `RGB(127,252,126)` instead of `RGB(253,255,255)`. Reproducible without cursor overlay: when cursor + click effect are disabled, output is clean white.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 340 passed / 11 skipped (was 338/11; +2 new regression tests pass)
- [x] New test fails before the fix (verified RED → GREEN)
- [x] Build emits the fixed filter strings in `dist/render/renderer.js`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)