### PR TITLE
fix: assemble video from screencast frames when no .webm sibling (closes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **Standalone trace.zip rendered with no source video** ([#6](https://github.com/ThePatriczek/playwright-recast/issues/6)) — Running `playwright-recast --input <trace>.zip` without a sibling `.webm` (e.g. a trace downloaded from the trace viewer, or a test run without `recordVideo`) failed deep in the renderer with the unhelpful message `Source video not found: undefined`. The renderer previously required a sibling `.webm` recorded by Playwright's `recordVideo` option and never consulted the screencast JPEG frames stored inside the trace zip itself. Pipeline now falls back to assembling a CFR 25fps `.mp4` from the trace's screencast frames (recording-page only, via ffmpeg's concat demuxer with per-frame durations) when no `.webm` is found, so `npx playwright-recast --input foo.trace.zip` works out of the box. If neither a `.webm` nor screencast frames are available, the executor fails fast with an actionable error pointing at the Playwright `video: 'on'` / `--trace=on` knobs. A sibling `.webm` is still preferred (higher native frame rate); the fallback exists so standalone traces aren't a dead end. Reported by [@odiszapc](https://github.com/odiszapc).
+
 ## 0.15.1 (2026-05-12)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ brew install ffmpeg
 sudo apt install ffmpeg
 ```
 
+**Trace inputs.** Two layouts work:
+
+- **Test-results directory** (preferred): pass a folder or `trace.zip` whose sibling is a `.webm` recorded by Playwright's `recordVideo` (`use: { video: 'on' }`). Native frame rate, best quality.
+- **Standalone `trace.zip`**: pass the zip alone — the pipeline assembles the source video from screencast JPEG frames stored inside the trace. Variable cadence (~capture rate), but works out of the box on traces from the Playwright trace viewer or test runs without `recordVideo`.
+
 ### CLI Usage
 
 ```bash

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -14,6 +14,10 @@ import { generateSubtitles } from '../subtitles/subtitle-generator.js'
 import { parseSrt } from '../subtitles/srt-parser.js'
 import { generateVoiceover } from '../voiceover/voiceover-processor.js'
 import { renderVideo, detectBlankLeadIn, type RenderableTrace } from '../render/renderer.js'
+import {
+  assembleVideoFromScreencastFrames,
+  selectRecordingPageFrames,
+} from '../render/screencast-assembler.js'
 import { processText } from '../text-processing/text-processor.js'
 import { writeSrt } from '../subtitles/srt-writer.js'
 import { writeVtt } from '../subtitles/vtt-writer.js'
@@ -248,6 +252,9 @@ export class PipelineExecutor {
             ...state.parsed,
             originalActions: state.parsed.actions,
             hiddenRanges: [],
+          }
+          if (!state.sourceVideoPath) {
+            state.sourceVideoPath = await this.assembleFallbackVideo(state.parsed)
           }
           break
         }
@@ -863,5 +870,36 @@ export class PipelineExecutor {
     }
 
     return searchDir(dir)
+  }
+
+  /**
+   * Build a video from the trace's screencast JPEG frames as a fallback
+   * when no sibling .webm exists. Only invoked from the parse stage when
+   * `findSourceVideo()` returned undefined — the happy path with a real
+   * recordVideo .webm bypasses this entirely. See issue #6.
+   */
+  private async assembleFallbackVideo(parsed: ParsedTrace): Promise<string> {
+    const pageFrames = selectRecordingPageFrames(parsed.frames)
+    if (pageFrames.length === 0) {
+      throw new Error(
+        'No source video found and the trace contains no screencast frames. ' +
+          'Enable `recordVideo` in your Playwright config (use: { video: \'on\' }) ' +
+          'so the .webm sits next to trace.zip, or run tests with --trace=on which ' +
+          'embeds screencast frames.',
+      )
+    }
+    const dir = this.source.endsWith('.zip')
+      ? path.dirname(this.source)
+      : this.source
+    const tmpDir = path.join(dir, '.recast-screencast-tmp')
+    const outputPath = path.join(tmpDir, 'screencast.mp4')
+    console.log(`  Source video: assembling from ${pageFrames.length} screencast frames (no sibling .webm)`)
+    await assembleVideoFromScreencastFrames({
+      frames: pageFrames,
+      readFrame: (sha1) => parsed.frameReader.readFrame(sha1),
+      tmpDir,
+      outputPath,
+    })
+    return outputPath
   }
 }

--- a/src/render/screencast-assembler.ts
+++ b/src/render/screencast-assembler.ts
@@ -1,0 +1,90 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import type { ScreencastFrame } from '../types/trace.js'
+
+const DEFAULT_TAIL_DURATION_SEC = 0.04
+const OUTPUT_FPS = 25
+
+export interface AssembleOptions {
+  frames: readonly ScreencastFrame[]
+  readFrame: (sha1: string) => Promise<Buffer>
+  tmpDir: string
+  outputPath: string
+}
+
+/**
+ * Assemble a video from Playwright screencast JPEG frames using ffmpeg's
+ * concat demuxer with per-frame durations. Used as a fallback when a trace
+ * has no sibling .webm video — keeps the rest of the render pipeline working
+ * against a single source file. The resulting video has variable frame rate
+ * matching the original screencast cadence.
+ */
+export async function assembleVideoFromScreencastFrames(opts: AssembleOptions): Promise<void> {
+  const { frames, readFrame, tmpDir, outputPath } = opts
+  if (frames.length === 0) {
+    throw new Error('Cannot assemble video: no screencast frames available')
+  }
+  fs.mkdirSync(tmpDir, { recursive: true })
+
+  const framePaths: string[] = []
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i]!
+    const data = await readFrame(frame.sha1)
+    const filePath = path.join(tmpDir, `frame-${i.toString().padStart(6, '0')}.jpg`)
+    fs.writeFileSync(filePath, data)
+    framePaths.push(filePath)
+  }
+
+  // ffmpeg concat demuxer requires the final `file` directive to be repeated
+  // so the duration declared for the last "real" entry actually takes effect.
+  const lines: string[] = ['ffconcat version 1.0']
+  for (let i = 0; i < frames.length - 1; i++) {
+    const cur = frames[i]!
+    const next = frames[i + 1]!
+    const duration = Math.max(0.001, ((next.timestamp as number) - (cur.timestamp as number)) / 1000)
+    lines.push(`file '${path.basename(framePaths[i]!)}'`)
+    lines.push(`duration ${duration.toFixed(6)}`)
+  }
+  const lastIdx = frames.length - 1
+  lines.push(`file '${path.basename(framePaths[lastIdx]!)}'`)
+  lines.push(`duration ${DEFAULT_TAIL_DURATION_SEC.toFixed(6)}`)
+  lines.push(`file '${path.basename(framePaths[lastIdx]!)}'`)
+
+  const concatPath = path.join(tmpDir, 'screencast-concat.txt')
+  fs.writeFileSync(concatPath, lines.join('\n') + '\n')
+
+  // Force CFR 25fps so downstream filters (zoom, overlay, speed) see a stable
+  // frame rate. The `fps` filter duplicates frames during idle pauses and
+  // drops during bursts — preserving the visual cadence of the screencast.
+  // 25fps matches Playwright's recordVideo default.
+  execFileSync('ffmpeg', [
+    '-y',
+    '-f', 'concat', '-safe', '0', '-i', concatPath,
+    // JPEG inputs come in yuvj420p (full range). Explicit `scale` with
+    // range conversion is the only reliable way to land at standard
+    // limited-range yuv420p — bare `format=yuv420p` keeps the full range.
+    '-vf', `fps=${OUTPUT_FPS},scale=ceil(iw/2)*2:ceil(ih/2)*2:in_range=full:out_range=tv,format=yuv420p`,
+    '-pix_fmt', 'yuv420p',
+    '-color_range', 'tv',
+    '-c:v', 'libx264', '-preset', 'fast', '-crf', '18',
+    '-r', String(OUTPUT_FPS),
+    outputPath,
+  ], { stdio: 'pipe' })
+}
+
+/**
+ * Pick the screencast frames that belong to the recording page. The
+ * recording page is the one whose last frame appears latest — same heuristic
+ * the renderer uses to align timing. Multi-tab traces with parallel
+ * framesets are collapsed to the dominant page so the assembled video
+ * matches a single continuous viewport.
+ */
+export function selectRecordingPageFrames(
+  frames: readonly ScreencastFrame[],
+): readonly ScreencastFrame[] {
+  if (frames.length === 0) return frames
+  const recordingPageId = frames[frames.length - 1]!.pageId
+  if (recordingPageId === undefined) return frames
+  return frames.filter((f) => f.pageId === recordingPageId)
+}

--- a/tests/unit/render/screencast-assembler.test.ts
+++ b/tests/unit/render/screencast-assembler.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import {
+  assembleVideoFromScreencastFrames,
+  selectRecordingPageFrames,
+} from '../../../src/render/screencast-assembler'
+import type { ScreencastFrame } from '../../../src/types/trace'
+import { toMonotonic } from '../../../src/types/trace'
+
+const TMP_DIR = path.join('/tmp', 'recast-screencast-test')
+
+function makeJpeg(label: string, color: string): Buffer {
+  const filePath = path.join(TMP_DIR, `seed-${label}.jpg`)
+  execFileSync(
+    'ffmpeg',
+    [
+      '-y', '-f', 'lavfi',
+      '-i', `color=c=${color}:s=320x240:d=0.1`,
+      '-frames:v', '1', '-q:v', '5', filePath,
+    ],
+    { stdio: 'pipe' },
+  )
+  const buf = fs.readFileSync(filePath)
+  fs.unlinkSync(filePath)
+  return buf
+}
+
+function ffprobe(field: string, file: string): string {
+  return execFileSync(
+    'ffprobe',
+    [
+      '-v', 'error',
+      '-select_streams', 'v:0',
+      '-show_entries', `stream=${field}`,
+      '-of', 'default=nw=1:nk=1',
+      file,
+    ],
+    { encoding: 'utf-8' },
+  ).trim()
+}
+
+function durationSec(file: string): number {
+  const out = execFileSync(
+    'ffprobe',
+    [
+      '-v', 'error',
+      '-show_entries', 'format=duration',
+      '-of', 'default=nw=1:nk=1',
+      file,
+    ],
+    { encoding: 'utf-8' },
+  ).trim()
+  return Number(out)
+}
+
+describe('screencast assembler', () => {
+  beforeAll(() => {
+    fs.mkdirSync(TMP_DIR, { recursive: true })
+  })
+
+  afterAll(() => {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true })
+  })
+
+  it('produces a CFR 25fps mp4 covering the screencast time span', async () => {
+    const sha = ['aaa', 'bbb', 'ccc']
+    const jpegs: Record<string, Buffer> = {
+      aaa: makeJpeg('red', 'red'),
+      bbb: makeJpeg('green', 'green'),
+      ccc: makeJpeg('blue', 'blue'),
+    }
+    const frames: ScreencastFrame[] = [
+      { sha1: sha[0]!, timestamp: toMonotonic(0), pageId: 'p1', width: 320, height: 240 },
+      { sha1: sha[1]!, timestamp: toMonotonic(500), pageId: 'p1', width: 320, height: 240 },
+      { sha1: sha[2]!, timestamp: toMonotonic(1500), pageId: 'p1', width: 320, height: 240 },
+    ]
+    const outputPath = path.join(TMP_DIR, 'assembled.mp4')
+
+    await assembleVideoFromScreencastFrames({
+      frames,
+      readFrame: (s) => Promise.resolve(jpegs[s]!),
+      tmpDir: path.join(TMP_DIR, 'work'),
+      outputPath,
+    })
+
+    expect(fs.existsSync(outputPath)).toBe(true)
+    expect(ffprobe('r_frame_rate', outputPath)).toBe('25/1')
+    expect(ffprobe('pix_fmt', outputPath)).toBe('yuv420p')
+    // Span is 0→1500ms + tail 40ms ≈ 1.54s
+    const dur = durationSec(outputPath)
+    expect(dur).toBeGreaterThan(1.4)
+    expect(dur).toBeLessThan(1.8)
+  })
+
+  it('rejects empty frame list with a clear error', async () => {
+    await expect(
+      assembleVideoFromScreencastFrames({
+        frames: [],
+        readFrame: () => Promise.resolve(Buffer.alloc(0)),
+        tmpDir: path.join(TMP_DIR, 'empty'),
+        outputPath: path.join(TMP_DIR, 'empty.mp4'),
+      }),
+    ).rejects.toThrow(/no screencast frames/i)
+  })
+})
+
+describe('selectRecordingPageFrames', () => {
+  it('returns the frames belonging to the page whose last frame appears latest', () => {
+    const frames: ScreencastFrame[] = [
+      { sha1: '1', timestamp: toMonotonic(0), pageId: 'a', width: 1, height: 1 },
+      { sha1: '2', timestamp: toMonotonic(50), pageId: 'b', width: 1, height: 1 },
+      { sha1: '3', timestamp: toMonotonic(100), pageId: 'a', width: 1, height: 1 },
+      { sha1: '4', timestamp: toMonotonic(200), pageId: 'b', width: 1, height: 1 },
+    ]
+    const picked = selectRecordingPageFrames(frames)
+    expect(picked.map((f) => f.sha1)).toEqual(['2', '4'])
+  })
+
+  it('returns the input unchanged when frames lack pageId', () => {
+    const frames: ScreencastFrame[] = [
+      { sha1: '1', timestamp: toMonotonic(0), width: 1, height: 1 },
+      { sha1: '2', timestamp: toMonotonic(50), width: 1, height: 1 },
+    ]
+    expect(selectRecordingPageFrames(frames)).toBe(frames)
+  })
+
+  it('returns empty for empty input', () => {
+    expect(selectRecordingPageFrames([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes [#6](https://github.com/ThePatriczek/playwright-recast/issues/6) — `npx playwright-recast --input <trace>.zip` crashed with `Fatal error: Source video not found: undefined` whenever the trace.zip had no sibling `.webm` (downloaded from the trace viewer, test run without `recordVideo`, etc.).

The renderer required a `.webm` recorded by Playwright's `recordVideo` and never read the screencast JPEG frames that live inside the trace zip itself. This PR adds a fallback: when `findSourceVideo()` finds no sibling `.webm`, the pipeline assembles a CFR 25fps `.mp4` from the trace's screencast frames (recording-page only) via ffmpeg's concat demuxer with per-frame durations. The rest of the render pipeline runs unchanged against that synthesised source.

If neither a sibling `.webm` nor screencast frames are present, the executor now fails fast with an actionable error pointing at the Playwright `video: 'on'` / `--trace=on` options instead of the cryptic `undefined` message.

A sibling `.webm` is still preferred (higher native frame rate); the fallback exists so standalone traces aren't a dead end.

## Changes

- `src/render/screencast-assembler.ts` (new) — `assembleVideoFromScreencastFrames` + `selectRecordingPageFrames` helpers.
- `src/pipeline/executor.ts` — fallback wired into `case 'parse'`; only triggers when `findSourceVideo()` returned `undefined`, so the happy `.webm` path is untouched.
- `tests/unit/render/screencast-assembler.test.ts` — 5 unit tests covering CFR/pix_fmt/duration, empty input, and recording-page selection.
- `README.md`, `CHANGELOG.md` — document the two supported input layouts.

## Backward compatibility

The fallback is guarded behind `if (!state.sourceVideoPath)` — when a sibling `.webm` exists (the original happy path), no new code runs. Verified: full suite 345/345 passing, including all existing render/pipeline/parse tests.

## Test plan

- [x] `npx vitest run tests/unit/render/screencast-assembler.test.ts` — 5/5 pass
- [x] `npx vitest run` (full suite) — 345 pass, 11 skipped, 0 failed
- [x] `npx tsc --noEmit` clean
- [ ] Manual: re-run the original repro from #6 (`npx playwright-recast --input inbox-login.trace.zip`) — should now produce a video instead of the `undefined` error
- [ ] Manual: confirm the happy `.webm`-sibling flow still produces an identical output to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)