### PR TITLE
feat(helpers): self-contained narrate / highlight / zoom via trace steps

### DIFF
--- a/.claude/playwright-recast/skills/recast-guide/SKILL.md
+++ b/.claude/playwright-recast/skills/recast-guide/SKILL.md
@@ -75,10 +75,10 @@ npx playwright-recast -i ./traces --srt narration.srt --burn-subs
 | `.speedUp(config)` | Adjust speed by activity type or explicit segments |
 | `.subtitles(textFn)` | Generate subtitles from trace actions |
 | `.subtitlesFromSrt(path)` | Load external SRT file |
-| `.subtitlesFromTrace()` | Auto-generate from BDD step titles |
+| `.subtitlesFromTrace()` | Auto-generate subtitles/highlights/zoom from `narrate()`/`highlight()`/`zoom()` marker steps; falls back to BDD step titles when no `narrate()` is present |
 | `.textProcessing(config)` | Sanitize subtitle text for TTS (strip quotes, normalize dashes, custom rules) |
 | `.autoZoom(config)` | Auto-zoom to user interaction targets from trace |
-| `.enrichZoomFromReport(steps)` | Apply zoom coordinates from external report data |
+| `.enrichZoomFromReport(steps)` | Apply zoom coordinates from external report data (legacy — prefer the `zoom()` helper which writes directly into the trace) |
 | `.clickEffect(config)` | Visual ripple + optional click sound at click positions |
 | `.voiceover(provider)` | Generate TTS from subtitle text |
 | `.render(config)` | Configure output format/resolution/fps/subtitle styling |
@@ -122,21 +122,29 @@ ElevenLabsProvider({ voiceId: 'onwK4e9ZLuTAKqWW03F9', modelId: 'eleven_multiling
 
 ## playwright-bdd Integration
 
-Step helpers for BDD test definitions:
+Step helpers for BDD test definitions. Each helper (`narrate`, `highlight`, `zoom`) writes a marker-prefixed `test.step()` directly into the trace zip — `subtitlesFromTrace()` picks them all up automatically. No separate `report.json` or extra pipeline calls required.
 
 ```typescript
-import { setupRecast, narrate, pace } from 'playwright-recast'
+import { setupRecast, narrate, highlight, zoom, pace } from 'playwright-recast'
 
 // In fixtures.ts — initialize once:
 setupRecast(test)
 
 // In step definitions:
 Given('the user opens dashboard', async ({ page }, docString?: string) => {
-  narrate(docString)              // Record voiceover text from Gherkin doc string
+  await narrate(docString)        // Records narration into the trace
   await page.goto('/dashboard')
   await pace(page, 4000)          // Pause for voiceover timing
 })
+
+When('the user reviews KPI', async ({ page }, docString?: string) => {
+  await narrate(docString, { autoWait: true }) // pad test by estimated speak time
+  await highlight(page.locator('h2'), { text: 'Revenue' })
+  await zoom(page.locator('.kpi-card'), 1.3)
+})
 ```
+
+**Voiceover-driven freezes:** when TTS audio is longer than its visual window the renderer holds the current frame until the audio finishes — overlays freeze with it, click sounds shift to match. No config required.
 
 Feature file with voiceover text:
 ```gherkin
@@ -164,11 +172,13 @@ Zoom into specific UI areas during steps. Three approaches:
 ])
 ```
 
-**From step helpers** — capture element bounding box during test:
+**From step helpers** — capture element bounding box during the test (writes marker into the trace; picked up automatically by `.subtitlesFromTrace()`):
 ```typescript
 import { zoom } from 'playwright-recast'
 await zoom(page.locator('.sidebar'), 1.3)
 ```
+
+Zoom starts at the `zoom()` call site (not at the parent narration's start) and runs until the end of the surrounding subtitle.
 
 Coordinates: `x` and `y` are viewport fractions (0.0–1.0), `level` is zoom factor (1.0 = none, 2.0 = 2x).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Self-contained `narrate()` / `highlight()` / `zoom()` helpers** — All three helpers now write marker-prefixed `test.step()` events directly into the Playwright trace zip. `subtitlesFromTrace()` recovers narration spans, highlight overlays, and per-subtitle zoom from the recorded marker steps — no `report.json` or extra pipeline calls (`.textHighlight()` / `.enrichZoomFromReport()`) required. The legacy pipeline stages remain available for non-Playwright highlight sources.
+- **Voiceover-driven freezes** — When a narration's TTS audio is longer than its visual window, the renderer now holds the current frame until the audio finishes. Overlays freeze with the frame and click sounds shift to match — audio-perfect sync without hand-tuning `pace()` calls.
+- **`narrate({ autoWait })`** — Pads the test by an estimated speaking time using a character-based heuristic (`NARRATE_DEFAULT_CPS = 14`). Accepts `true`, an explicit millisecond count, or `{ charactersPerSecond, minMs, maxMs }`. Useful when running without TTS so the recorded video has natural visual time for each line.
+- **`render({ embedSubtitles })`** — Muxes a soft (toggleable) subtitle track into the container: `mov_text` for mp4, `webvtt` for webm. Accepts `true` for defaults or `{ language, title, default }` to customize. Can be combined with `burnSubtitles`.
+
+### Behavior changes
+
+- **Zoom marker start time** — Zoom now starts at the `zoom()` call site (in-window) rather than at the parent narration's start, so the camera kicks in only once the target is visible. The same shifts that move `subtitle.startMs` (blank-trim, voiceover `timeShift`) now also move `zoom.startMs` / `zoom.endMs`.
+
 ## 0.15.2 (2026-05-15)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ await Recast
 - **Cursor overlay** — Animated cursor appears before each click, moves to the click position with ease-out animation, then disappears. Bundled arrow cursor or custom image.
 - **Animated zoom with easing** — Auto-zoom uses customizable easing functions (ease-in-out, ease-out, cubic-bezier, or custom JS functions) with smooth zoom-to-zoom panning.
 - **Frame interpolation** — Smooth out choppy browser recordings with ffmpeg minterpolate. Blend, duplicate, or motion-compensated modes with multi-pass support.
-- **Step helpers** — `narrate()`, `zoom()`, `pace()` — importable helpers for Playwright step definitions.
+- **Step helpers** — `narrate()`, `highlight()`, `zoom()`, `pace()` — importable helpers for Playwright step definitions. `narrate/highlight/zoom` write marker steps directly into the trace zip, so the pipeline picks them up automatically via `subtitlesFromTrace()` (no `report.json` or extra pipeline calls needed).
+- **Voiceover-driven freezes** — When a TTS narration is longer than its visual window, the renderer holds the current frame until the audio finishes; overlays freeze with it, click sounds shift to match.
+- **Soft (embedded) subtitle track** — `render({ embedSubtitles: true })` muxes a toggleable subtitle track into the container (`mov_text` for mp4, `webvtt` for webm).
 - **Background music** — Add background music with auto-ducking during voiceover, looping, and fade-out. Covers intro/outro.
 - **Intro/outro** — Prepend/append branded video clips with smooth crossfade transitions. Audio preserved.
 - **MCP server** — AI-assisted video creation via Model Context Protocol. Record, analyze, and render through any MCP-compatible client (Claude Code, etc.).
@@ -151,26 +153,34 @@ await Recast
 
 ### playwright-bdd Integration
 
-Use `narrate()` and `pace()` in your BDD step definitions:
+Use `narrate()`, `highlight()`, `zoom()`, and `pace()` in your BDD step definitions:
 
 ```typescript
 // steps/fixtures.ts
 import { test } from 'playwright-bdd'
-import { setupRecast, narrate, pace } from 'playwright-recast'
+import { setupRecast, narrate, highlight, zoom, pace } from 'playwright-recast'
 
 setupRecast(test)
-export { narrate, pace }
+export { narrate, highlight, zoom, pace }
 
 // steps/my-steps.ts
 import { Given, When, Then } from './fixtures'
-import { narrate, pace } from 'playwright-recast'
+import { narrate, highlight, zoom, pace } from 'playwright-recast'
 
 Given('the user opens the dashboard', async ({ page }, docString?: string) => {
-  narrate(docString)
+  await narrate(docString)
   await page.goto('/dashboard')
   await pace(page, 4000)
 })
+
+When('the user highlights revenue', async ({ page }, docString?: string) => {
+  await narrate(docString, { autoWait: true })  // pad test with estimated speak time
+  await highlight(page.locator('h2'), { text: 'Revenue' })
+  await zoom(page.locator('.kpi-card'), 1.3)
+})
 ```
+
+Each helper writes a marker-prefixed `test.step()` into the trace zip — `subtitlesFromTrace()` picks them all up and the renderer applies overlays, zoom, and per-narration timing automatically.
 
 ```gherkin
 Feature: Dashboard demo

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -88,8 +88,13 @@ export async function narrate(
 ): Promise<void> {
   const hidden = opts?.hidden ?? text?.includes('@hidden') ?? false
   const cleanText = text?.replace(/@hidden\s*/g, '').trim() || ''
-  if (!cleanText) return
 
+  // Always push annotations — even for empty/hidden steps — so external
+  // reporters that map annotations to BDD steps by sequential index (the
+  // legacy report.json contract) stay consistent. A `narrate(undefined,
+  // {hidden:true})` call must still produce one voiceover + one
+  // voiceover-hidden annotation, otherwise downstream highlight/zoom
+  // annotations get attributed to the wrong step.
   const info = _getTestInfo()
   info.annotations.push({ type: 'voiceover', description: cleanText })
   info.annotations.push({
@@ -97,7 +102,10 @@ export async function narrate(
     description: hidden ? '1' : '0',
   })
 
-  if (_step) {
+  // The trace marker step is only useful when there is text to record;
+  // empty steps would just clutter the trace. `subtitlesFromTrace` skips
+  // hidden markers anyway.
+  if (cleanText && _step) {
     const prefix = hidden ? NARRATE_HIDDEN_TITLE_PREFIX : NARRATE_TITLE_PREFIX
     await _step(`${prefix}${cleanText}`, async () => {})
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,47 +1,94 @@
 import type { Page, Locator, TestInfo } from '@playwright/test'
 
+type StepFn = <T>(title: string, body: () => T | Promise<T>) => Promise<T>
+type RecastTest = { info: () => TestInfo; step: StepFn }
+
 /**
  * Get current test info — works in both playwright-bdd and standard Playwright.
  * Must be called from within a test context.
  */
 function getTestInfo(): TestInfo {
-  // @playwright/test provides test.info() but we can't import 'test' generically.
-  // Instead, we use the global __test_info__ or accept it as parameter.
   throw new Error(
-    'getTestInfo() must be overridden. Call Recast.setup(test) first.',
+    'getTestInfo() must be overridden. Call setupRecast(test) first.',
   )
 }
 
 let _getTestInfo: () => TestInfo = getTestInfo
+let _step: StepFn | null = null
+
+/**
+ * Title prefix written to a trace step by `narrate()`. The `subtitlesFromTrace`
+ * pipeline stage looks for this prefix to recover the narration text and
+ * compute the subtitle's time window (this narrate → next narrate).
+ */
+export const NARRATE_TITLE_PREFIX = '__recast_narrate__: '
+/** Same as `NARRATE_TITLE_PREFIX` but the step is excluded from subtitles. */
+export const NARRATE_HIDDEN_TITLE_PREFIX = '__recast_narrate_hidden__: '
+/** Title prefix written to a trace step by `highlight()`. JSON payload carries
+ *  the viewport-pixel bounding box and styling overrides. */
+export const HIGHLIGHT_TITLE_PREFIX = '__recast_highlight__: '
+/** Title prefix written to a trace step by `zoom()`. JSON payload carries
+ *  the center as (x, y) viewport fractions and the zoom level. */
+export const ZOOM_TITLE_PREFIX = '__recast_zoom__: '
+
+/** Characters-per-second used by `narrate({ autoWait: true })` to estimate
+ *  how long the narration will take to speak. Character count is more
+ *  language-robust than word count (cf. German compounds vs. English).
+ *  14 ch/s ≈ 150 wpm × 5 chars/word / 60s, a typical conversational pace. */
+export const NARRATE_DEFAULT_CPS = 14
+
+function estimateNarrationMs(text: string, charsPerSecond: number): number {
+  // Count non-whitespace characters — whitespace inflates length without
+  // adding spoken time.
+  const chars = text.replace(/\s+/g, '').length
+  if (chars === 0 || charsPerSecond <= 0) return 0
+  return Math.round((chars / charsPerSecond) * 1000)
+}
 
 /**
  * Initialize playwright-recast helpers with the test instance.
  * Call once in your fixtures file:
  *
  * ```typescript
- * import { test } from 'playwright-bdd'
- * import { setupRecast } from '@workspace/playwright-recast/helpers'
+ * import { test } from 'playwright-bdd' // or '@playwright/test'
+ * import { setupRecast } from 'playwright-recast'
  * setupRecast(test)
  * ```
  */
-export function setupRecast(testInstance: { info: () => TestInfo }): void {
+export function setupRecast(testInstance: RecastTest): void {
   _getTestInfo = () => testInstance.info()
+  _step = testInstance.step.bind(testInstance)
 }
 
 /**
- * Attach voiceover narration text to the current step.
- * Call from EVERY step definition (even without doc string) so
- * the reporter can match annotations to steps by sequential index.
+ * Attach voiceover narration text to the current point in the test.
  *
- * @param text Doc string content (voiceover text). Pass undefined if none.
- * @param opts.hidden Mark step as hidden (not recorded, excluded from SRT)
+ * Emits a `test.step()` with a marker-prefixed title so the narration is
+ * recorded in the trace zip. `subtitlesFromTrace` later groups each narrate
+ * step's text into a subtitle that spans until the next narrate call (or the
+ * end of the trace). Also pushes a `voiceover` annotation onto `testInfo` so
+ * external reporters can still read it from the JSON report.
+ *
+ * @param text Narration text. Pass undefined to no-op.
+ * @param opts.hidden Mark step as hidden (excluded from SRT). Detected
+ *   automatically if `text` contains `@hidden`.
+ * @param opts.autoWait Pause the test after recording the step for the
+ *   approximate time the narration takes to speak. Useful when running
+ *   without TTS so the recorded video has natural visual time for the line.
+ *   - `true` — estimate via non-whitespace characters / `NARRATE_DEFAULT_CPS`.
+ *   - `number` — wait exactly this many milliseconds.
+ *   - `{ charactersPerSecond, minMs, maxMs }` — tune the estimate.
  */
-export function narrate(
+export async function narrate(
   text: string | undefined,
-  opts?: { hidden?: boolean },
-): void {
+  opts?: {
+    hidden?: boolean
+    autoWait?: boolean | number | { charactersPerSecond?: number; minMs?: number; maxMs?: number }
+  },
+): Promise<void> {
   const hidden = opts?.hidden ?? text?.includes('@hidden') ?? false
   const cleanText = text?.replace(/@hidden\s*/g, '').trim() || ''
+  if (!cleanText) return
 
   const info = _getTestInfo()
   info.annotations.push({ type: 'voiceover', description: cleanText })
@@ -49,6 +96,35 @@ export function narrate(
     type: 'voiceover-hidden',
     description: hidden ? '1' : '0',
   })
+
+  if (_step) {
+    const prefix = hidden ? NARRATE_HIDDEN_TITLE_PREFIX : NARRATE_TITLE_PREFIX
+    await _step(`${prefix}${cleanText}`, async () => {})
+  }
+
+  const waitMs = resolveAutoWait(cleanText, opts?.autoWait)
+  if (waitMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, waitMs))
+  }
+}
+
+function resolveAutoWait(
+  text: string,
+  autoWait:
+    | boolean
+    | number
+    | { charactersPerSecond?: number; minMs?: number; maxMs?: number }
+    | undefined,
+): number {
+  if (!autoWait) return 0
+  if (typeof autoWait === 'number') return Math.max(0, autoWait)
+  const cps =
+    (typeof autoWait === 'object' && autoWait.charactersPerSecond) || NARRATE_DEFAULT_CPS
+  const minMs = (typeof autoWait === 'object' && autoWait.minMs) || 0
+  const maxMs = typeof autoWait === 'object' ? autoWait.maxMs : undefined
+  const estimated = estimateNarrationMs(text, cps)
+  const clampedLow = Math.max(minMs, estimated)
+  return maxMs !== undefined ? Math.min(maxMs, clampedLow) : clampedLow
 }
 
 /**
@@ -72,11 +148,16 @@ export async function zoom(
 
   const x = (box.x + box.width / 2) / viewport.width
   const y = (box.y + box.height / 2) / viewport.height
+  const payload = { x, y, level }
 
   _getTestInfo().annotations.push({
     type: 'zoom',
-    description: JSON.stringify({ x, y, level }),
+    description: JSON.stringify(payload),
   })
+
+  if (_step) {
+    await _step(`${ZOOM_TITLE_PREFIX}${JSON.stringify(payload)}`, async () => {})
+  }
 }
 
 /**
@@ -178,16 +259,22 @@ export async function highlight(
 
   if (!box) return
 
+  const payload = {
+    x: box.x,
+    y: box.y,
+    width: box.width,
+    height: box.height,
+    ...styleOpts,
+  }
+
   _getTestInfo().annotations.push({
     type: 'highlight',
-    description: JSON.stringify({
-      x: box.x,
-      y: box.y,
-      width: box.width,
-      height: box.height,
-      ...styleOpts,
-    }),
+    description: JSON.stringify(payload),
   })
+
+  if (_step) {
+    await _step(`${HIGHLIGHT_TITLE_PREFIX}${JSON.stringify(payload)}`, async () => {})
+  }
 }
 
 /**

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -5,7 +5,13 @@ import type { StageDescriptor } from './stages.js'
 import type { ParsedTrace, FilteredTrace, TraceAction } from '../types/trace.js'
 import { toMonotonic } from '../types/trace.js'
 import type { SpeedMappedTrace } from '../types/speed.js'
-import type { SubtitledTrace } from '../types/subtitle.js'
+import type { SubtitledTrace, SubtitleEntry } from '../types/subtitle.js'
+import {
+  NARRATE_TITLE_PREFIX,
+  NARRATE_HIDDEN_TITLE_PREFIX,
+  HIGHLIGHT_TITLE_PREFIX,
+  ZOOM_TITLE_PREFIX,
+} from '../helpers.js'
 import type { VoiceoveredTrace } from '../types/voiceover.js'
 import { parseTrace } from '../parse/trace-parser.js'
 import { filterSteps } from '../filter/step-filter.js'
@@ -89,7 +95,10 @@ export class PipelineExecutor {
     // and voiceover/subtitle timing is already adjusted for this in the voiceover/render
     // cases. But click sound timing and cursor keyframes are computed earlier without
     // this compensation, causing audio desync when blank lead-in is non-zero.
-    if (state.sourceVideoPath && (state.clickEvents || state.cursorKeyframes)) {
+    if (
+      state.sourceVideoPath &&
+      (state.clickEvents || state.cursorKeyframes || state.highlightEvents)
+    ) {
       const blankTmpDir = path.join(outputDir, '.recast-blank-probe')
       fs.mkdirSync(blankTmpDir, { recursive: true })
       const blankLeadIn = detectBlankLeadIn(state.sourceVideoPath, blankTmpDir)
@@ -104,6 +113,12 @@ export class PipelineExecutor {
         if (state.cursorKeyframes) {
           for (const kf of state.cursorKeyframes) {
             kf.videoTimeSec = Math.max(0, kf.videoTimeSec - blankLeadIn)
+          }
+        }
+        if (state.highlightEvents) {
+          for (const he of state.highlightEvents) {
+            he.videoTimeMs = Math.max(0, Math.round(he.videoTimeMs - offsetMs))
+            he.endTimeMs = Math.max(0, Math.round(he.endTimeMs - offsetMs))
           }
         }
       }
@@ -414,11 +429,113 @@ export class PipelineExecutor {
             }
           }
 
-          // Extract BDD step text from trace actions
-          const defaultTextFn = (action: TraceAction): string | undefined =>
-            action.text ?? (action.keyword ? `${action.keyword} ${action.title}` : undefined)
+          // If the test used narrate(), prefer the explicit narration spans.
+          // narrate() emits a test.step with a marker-prefixed title; each
+          // narrate's subtitle spans from its start until the next narrate
+          // (or the end of the trace).
+          const narrateActions = speedMapped.actions.filter(
+            (a) =>
+              typeof a.title === 'string' &&
+              (a.title.startsWith(NARRATE_TITLE_PREFIX) ||
+                a.title.startsWith(NARRATE_HIDDEN_TITLE_PREFIX)),
+          )
 
-          state.subtitled = generateSubtitles(speedMapped, defaultTextFn, stage.options)
+          if (narrateActions.length > 0) {
+            const subtitles: SubtitleEntry[] = []
+            const traceEndMs = speedMapped.timeRemap(speedMapped.metadata.endTime)
+            for (let i = 0; i < narrateActions.length; i++) {
+              const current = narrateActions[i]!
+              const next = narrateActions[i + 1]
+              const hidden = current.title.startsWith(NARRATE_HIDDEN_TITLE_PREFIX)
+              if (hidden) continue
+              const text = current.title.slice(NARRATE_TITLE_PREFIX.length)
+              const startMs = speedMapped.timeRemap(current.startTime)
+              const endMs = next ? speedMapped.timeRemap(next.startTime) : traceEndMs
+              if (endMs <= startMs) continue
+              subtitles.push({
+                index: subtitles.length + 1,
+                startMs: Math.round(startMs),
+                endMs: Math.round(endMs),
+                text,
+              })
+            }
+            state.subtitled = { ...speedMapped, subtitles }
+          } else {
+            // Fall back to BDD step text / titles.
+            const defaultTextFn = (action: TraceAction): string | undefined =>
+              action.text ?? (action.keyword ? `${action.keyword} ${action.title}` : undefined)
+            state.subtitled = generateSubtitles(speedMapped, defaultTextFn, stage.options)
+          }
+
+          // Pick up highlight() and zoom() marker steps from the trace so the
+          // user doesn't need a separate report.json or an extra pipeline call.
+
+          const hlDefaults = resolveTextHighlightConfig({})
+          const traceHighlights: HighlightEvent[] = []
+          for (const action of speedMapped.actions) {
+            if (typeof action.title !== 'string') continue
+            if (!action.title.startsWith(HIGHLIGHT_TITLE_PREFIX)) continue
+            try {
+              const data = JSON.parse(action.title.slice(HIGHLIGHT_TITLE_PREFIX.length)) as {
+                x: number; y: number; width: number; height: number
+                color?: string; opacity?: number; duration?: number
+                fadeOut?: number; swipeDuration?: number
+              }
+              const videoTimeMs = Math.max(0, Math.round(speedMapped.timeRemap(action.startTime)))
+              const duration = data.duration ?? hlDefaults.duration
+              const fadeOut = data.fadeOut ?? hlDefaults.fadeOut
+              traceHighlights.push({
+                x: data.x,
+                y: data.y,
+                width: data.width,
+                height: data.height,
+                videoTimeMs,
+                endTimeMs: videoTimeMs + duration + fadeOut,
+                color: data.color ?? hlDefaults.color,
+                opacity: data.opacity ?? hlDefaults.opacity,
+                swipeDuration: data.swipeDuration ?? hlDefaults.swipeDuration,
+                fadeOut,
+              })
+            } catch {
+              // skip malformed markers
+            }
+          }
+          if (traceHighlights.length > 0) {
+            state.highlightEvents = traceHighlights
+            state.highlightConfig = hlDefaults
+            console.log(`  highlight: ${traceHighlights.length} from trace`)
+          }
+
+          if (state.subtitled) {
+            for (const action of speedMapped.actions) {
+              if (typeof action.title !== 'string') continue
+              if (!action.title.startsWith(ZOOM_TITLE_PREFIX)) continue
+              try {
+                const data = JSON.parse(action.title.slice(ZOOM_TITLE_PREFIX.length)) as {
+                  x: number; y: number; level: number
+                }
+                const tMs = speedMapped.timeRemap(action.startTime)
+                const sub = state.subtitled.subtitles.find(
+                  (s) => tMs >= s.startMs && tMs < s.endMs,
+                )
+                if (sub) {
+                  // Start zoom at the actual zoom() marker time within the
+                  // narration window (not at the narration's start), so the
+                  // zoom kicks in only once the target is visible. The
+                  // renderer holds the zoom until `sub.endMs` since we leave
+                  // `zoom.endMs` undefined.
+                  sub.zoom = {
+                    x: data.x,
+                    y: data.y,
+                    level: data.level,
+                    startMs: Math.round(tMs),
+                  }
+                }
+              } catch {
+                // skip malformed markers
+              }
+            }
+          }
           break
         }
 
@@ -786,6 +903,12 @@ export class PipelineExecutor {
               for (const sub of state.subtitled.subtitles) {
                 sub.startMs = Math.max(0, sub.startMs - offsetMs)
                 sub.endMs = Math.max(0, sub.endMs - offsetMs)
+                if (sub.zoom?.startMs !== undefined) {
+                  sub.zoom.startMs = Math.max(0, sub.zoom.startMs - offsetMs)
+                }
+                if (sub.zoom?.endMs !== undefined) {
+                  sub.zoom.endMs = Math.max(0, sub.zoom.endMs - offsetMs)
+                }
               }
             }
             state._blankTrimApplied = true
@@ -813,6 +936,12 @@ export class PipelineExecutor {
               for (const sub of state.subtitled.subtitles) {
                 sub.startMs = Math.max(0, sub.startMs - offsetMs)
                 sub.endMs = Math.max(0, sub.endMs - offsetMs)
+                if (sub.zoom?.startMs !== undefined) {
+                  sub.zoom.startMs = Math.max(0, sub.zoom.startMs - offsetMs)
+                }
+                if (sub.zoom?.endMs !== undefined) {
+                  sub.zoom.endMs = Math.max(0, sub.zoom.endMs - offsetMs)
+                }
               }
             }
             state._blankTrimApplied = true

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -70,7 +70,12 @@ export function detectBlankLeadIn(videoPath: string, tmpDir: string): number {
 export interface RenderableTrace extends ParsedTrace {
   sourceVideoPath?: string
   subtitles?: SubtitleEntry[]
-  voiceover?: { audioTrackPath: string; entries: unknown[]; totalDurationMs: number }
+  voiceover?: {
+    audioTrackPath: string
+    entries: unknown[]
+    totalDurationMs: number
+    freezes?: Array<{ atVideoMs: number; durationMs: number }>
+  }
   speedSegments?: SpeedSegment[]
   clickEvents?: ClickEvent[]
   clickEffectConfig?: { color: string; opacity: number; radius: number; duration: number; soundVolume: number; sound?: string | true }
@@ -471,6 +476,93 @@ function renderWithSpeed(
 }
 
 /**
+ * Hold the last frame at each freeze point so the narration audio has time to
+ * finish before the next visual action. Splits the video at each freeze
+ * position, holds the last frame of the preceding segment for the requested
+ * duration, then concatenates everything back together.
+ *
+ * Freeze positions are in the speed-mapped (pre-freeze) video timeline.
+ */
+function applyVoiceoverFreezes(
+  videoPath: string,
+  freezes: Array<{ atVideoMs: number; durationMs: number }>,
+  tmpDir: string,
+): string {
+  if (freezes.length === 0) return videoPath
+
+  const videoDur = getVideoDuration(videoPath)
+  const sorted = [...freezes]
+    .map((f) => ({
+      atSec: Math.max(0, Math.min(videoDur, f.atVideoMs / 1000)),
+      durSec: Math.max(0, f.durationMs / 1000),
+    }))
+    .filter((f) => f.durSec > 0.01 && f.atSec < videoDur - 0.01)
+    .sort((a, b) => a.atSec - b.atSec)
+
+  if (sorted.length === 0) return videoPath
+
+  const segPaths: string[] = []
+  let prevEnd = 0
+  for (let i = 0; i < sorted.length; i++) {
+    const f = sorted[i]!
+    if (f.atSec <= prevEnd + 0.01) continue
+    const segPath = path.join(tmpDir, `vo-freeze-seg-${i}.mp4`)
+    ffmpeg([
+      '-y', '-ss', String(prevEnd), '-to', String(f.atSec),
+      '-i', videoPath,
+      '-vf', `tpad=stop_mode=clone:stop_duration=${f.durSec.toFixed(3)}`,
+      '-c:v', 'libx264', '-preset', 'fast', '-crf', '18', '-an',
+      segPath,
+    ])
+    segPaths.push(segPath)
+    prevEnd = f.atSec
+  }
+
+  if (prevEnd < videoDur - 0.01) {
+    const tailPath = path.join(tmpDir, 'vo-freeze-seg-tail.mp4')
+    ffmpeg([
+      '-y', '-ss', String(prevEnd),
+      '-i', videoPath,
+      '-c:v', 'libx264', '-preset', 'fast', '-crf', '18', '-an',
+      tailPath,
+    ])
+    segPaths.push(tailPath)
+  }
+
+  const totalFreezeSec = sorted.reduce((a, b) => a + b.durSec, 0)
+  console.log(
+    `  Voiceover freeze: ${sorted.length} hold(s), +${totalFreezeSec.toFixed(1)}s`,
+  )
+
+  const concatList = path.join(tmpDir, 'vo-freeze-concat.txt')
+  fs.writeFileSync(
+    concatList,
+    segPaths.map((p) => `file '${path.basename(p)}'`).join('\n'),
+  )
+  const outputPath = path.join(tmpDir, 'vo-freezed.mp4')
+  ffmpeg([
+    '-y', '-f', 'concat', '-safe', '0', '-i', concatList,
+    '-c', 'copy', outputPath,
+  ])
+  return outputPath
+}
+
+/**
+ * Shift a pre-freeze video time forward by the cumulative freeze duration
+ * that comes before it.
+ */
+function shiftForFreezes(
+  originalMs: number,
+  freezes: Array<{ atVideoMs: number; durationMs: number }>,
+): number {
+  let shift = 0
+  for (const f of freezes) {
+    if (f.atVideoMs <= originalMs) shift += f.durationMs
+  }
+  return originalMs + shift
+}
+
+/**
  * Render final video from trace data.
  */
 export function renderVideo(
@@ -573,6 +665,23 @@ export function renderVideo(
     )
   }
 
+  // Phase 3.6: Voiceover-driven freezes. If a narration's audio is longer
+  // than its visual window, the voiceover stage records "freeze" points so
+  // the video holds the current frame until the audio finishes. Visual
+  // overlays (cursor, click, highlight) are already baked into `videoInput`,
+  // so they freeze with the frame for free.
+  const voiceoverFreezes = trace.voiceover?.freezes ?? []
+  if (voiceoverFreezes.length > 0) {
+    videoInput = applyVoiceoverFreezes(videoInput, voiceoverFreezes, tmpDir)
+    // Shift click event times so the sound track lines up with the freeze-
+    // shifted visual ripples (which moved with the frozen frames).
+    if (trace.clickEvents) {
+      for (const ce of trace.clickEvents) {
+        ce.videoTimeMs = shiftForFreezes(ce.videoTimeMs, voiceoverFreezes)
+      }
+    }
+  }
+
   // Phase 3.7: Generate click sound track if configured
   let clickSoundTrackPath: string | undefined
   if (trace.clickEvents && trace.clickEvents.length > 0 && trace.clickEffectConfig?.sound) {
@@ -659,6 +768,23 @@ export function renderVideo(
     ffmpegArgs.push('-i', finalAudioPath)
   }
 
+  // Optional soft-subtitle track muxed into the container. The viewer can
+  // toggle this on/off in their player (independent of any burned-in style).
+  // All `-i` inputs MUST be pushed before any output options like `-vf` or
+  // `-map`, otherwise ffmpeg attributes those options to the wrong file.
+  const embedOpt = config.embedSubtitles
+  const wantEmbed = !!embedOpt && trace.subtitles && trace.subtitles.length > 0
+  let subInputIndex = -1
+  if (wantEmbed) {
+    const embedEntries = config.subtitleStyle?.chunkOptions
+      ? chunkSubtitles(trace.subtitles!, config.subtitleStyle.chunkOptions)
+      : trace.subtitles!
+    const embedSrtPath = path.join(tmpDir, 'embed-subtitles.srt')
+    fs.writeFileSync(embedSrtPath, writeSrt(embedEntries))
+    subInputIndex = finalAudioPath ? 2 : 1
+    ffmpegArgs.push('-i', embedSrtPath)
+  }
+
   const vFilters: string[] = []
 
   // Pad video with last frame to match audio duration
@@ -695,6 +821,14 @@ export function renderVideo(
     ffmpegArgs.push('-vf', vFilters.join(','))
   }
 
+  if (wantEmbed) {
+    // With extra inputs, explicit -map is needed so ffmpeg picks all three
+    // streams instead of falling back to its single-best-stream default.
+    ffmpegArgs.push('-map', '0:v:0')
+    if (finalAudioPath) ffmpegArgs.push('-map', '1:a:0')
+    ffmpegArgs.push('-map', `${subInputIndex}:s:0`)
+  }
+
   if (format === 'mp4') {
     ffmpegArgs.push('-c:v', config.codec ?? 'libx264', '-preset', 'fast', '-crf', String(crf))
   } else {
@@ -703,6 +837,21 @@ export function renderVideo(
 
   if (finalAudioPath) {
     ffmpegArgs.push('-c:a', 'aac', '-b:a', '128k')
+  }
+
+  if (wantEmbed) {
+    // mp4 uses mov_text; webm uses webvtt. ffmpeg transcodes the SRT input
+    // into the chosen codec automatically.
+    ffmpegArgs.push('-c:s', format === 'mp4' ? 'mov_text' : 'webvtt')
+
+    const meta = typeof embedOpt === 'object' && embedOpt ? embedOpt : {}
+    const language = meta.language ?? 'eng'
+    const title = meta.title ?? 'Subtitles'
+    ffmpegArgs.push(`-metadata:s:s:0`, `language=${language}`)
+    ffmpegArgs.push(`-metadata:s:s:0`, `title=${title}`)
+    if (meta.default !== false) {
+      ffmpegArgs.push('-disposition:s:0', 'default')
+    }
   }
 
   if (config.fps) {

--- a/src/types/render.ts
+++ b/src/types/render.ts
@@ -17,7 +17,17 @@ export interface RenderConfig {
   format?: 'mp4' | 'webm'
   resolution?: '720p' | '1080p' | '1440p' | '4k' | { width: number; height: number }
   fps?: number
+  /** Burn subtitles into the video pixels (cannot be turned off by the viewer). */
   burnSubtitles?: boolean
+  /**
+   * Mux subtitles as a soft (toggleable) track inside the container.
+   * - `true` — embed with default settings (language `eng`, title `Subtitles`).
+   * - `{ language, title, default }` — customize.
+   * Works with both `mp4` (mov_text codec) and `webm` (webvtt codec). Can be
+   * combined with `burnSubtitles` — viewers will see the burned-in version
+   * regardless, and can also toggle the embedded track in their player.
+   */
+  embedSubtitles?: boolean | { language?: string; title?: string; default?: boolean }
   subtitleStyle?: SubtitleStyle
   cursorOverlay?: boolean
   codec?: string

--- a/src/types/voiceover.ts
+++ b/src/types/voiceover.ts
@@ -68,11 +68,28 @@ export interface VoiceoverEntry {
   outputEndMs: number
 }
 
+/**
+ * A point in the (post-speed, pre-voiceover-shift) video timeline where the
+ * renderer should hold the current frame so the narration audio has time to
+ * finish. Emitted by `generateVoiceover` when a segment's audio is longer
+ * than the visual window between this narration and the next.
+ */
+export interface VoiceoverFreeze {
+  /** Video time (ms) at which to freeze — measured in the source video's
+   *  speed-mapped timeline, i.e. the same timeline `SpeedMappedTrace.timeRemap`
+   *  produces, before any voiceover shift was applied. */
+  atVideoMs: number
+  /** How long to hold the frame, in ms. */
+  durationMs: number
+}
+
 /** Trace after voiceover has been generated */
 export interface VoiceoveredTrace extends SubtitledTrace {
   voiceover: {
     entries: VoiceoverEntry[]
     audioTrackPath: string
     totalDurationMs: number
+    /** Frames to hold so the narration audio always finishes in-frame. */
+    freezes: VoiceoverFreeze[]
   }
 }

--- a/src/voiceover/voiceover-processor.ts
+++ b/src/voiceover/voiceover-processor.ts
@@ -6,6 +6,7 @@ import type {
   TtsProvider,
   VoiceoveredTrace,
   VoiceoverEntry,
+  VoiceoverFreeze,
   VoiceoverOptions,
   LoudnessNormalizeConfig,
 } from '../types/voiceover.js'
@@ -57,6 +58,11 @@ export async function generateVoiceover(
 
   const entries: VoiceoverEntry[] = []
   const segmentFiles: string[] = []
+  const freezes: VoiceoverFreeze[] = []
+  // Capture each subtitle's pre-mutation startMs — these are the video
+  // positions (in the speed-mapped timeline) where we may need to freeze
+  // the frame so audio has time to finish.
+  const originalStartsMs = trace.subtitles.map((s) => s.startMs)
   let cursor = 0
   let timeShift = 0
 
@@ -65,6 +71,8 @@ export async function generateVoiceover(
 
     subtitle.startMs += timeShift
     subtitle.endMs += timeShift
+    if (subtitle.zoom?.startMs !== undefined) subtitle.zoom.startMs += timeShift
+    if (subtitle.zoom?.endMs !== undefined) subtitle.zoom.endMs += timeShift
 
     if (subtitle.startMs > cursor) {
       const silencePath = path.join(tmpDir, `silence-${subtitle.index}.mp3`)
@@ -103,6 +111,17 @@ export async function generateVoiceover(
       const overflow = audioDuration - windowDuration
       segmentFiles.push(segPath)
       subtitle.endMs = subtitle.startMs + audioDuration
+      // Freeze the video on the last frame of this segment's window so the
+      // narration finishes before the next visual action starts. The final
+      // segment has nothing to freeze against; the renderer's end-of-video
+      // tpad handles its overflow instead.
+      const nextOriginalStartMs = originalStartsMs[si + 1]
+      if (nextOriginalStartMs !== undefined) {
+        freezes.push({
+          atVideoMs: nextOriginalStartMs,
+          durationMs: overflow,
+        })
+      }
       timeShift += overflow
       cursor = subtitle.endMs
     }
@@ -141,6 +160,7 @@ export async function generateVoiceover(
       entries,
       audioTrackPath,
       totalDurationMs,
+      freezes,
     },
   }
 }

--- a/tests/unit/helpers/markers.test.ts
+++ b/tests/unit/helpers/markers.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { TestInfo, Locator } from '@playwright/test'
+import {
+  zoom,
+  highlight,
+  setupRecast,
+  HIGHLIGHT_TITLE_PREFIX,
+  ZOOM_TITLE_PREFIX,
+} from '../../../src/helpers'
+
+type StepRecord = { title: string }
+
+function makeFakeTest() {
+  const annotations: Array<{ type: string; description?: string }> = []
+  const steps: StepRecord[] = []
+  const info = { annotations } as unknown as TestInfo
+  return {
+    info,
+    annotations,
+    steps,
+    fakeTest: {
+      info: () => info,
+      step: async <T,>(title: string, body: () => T | Promise<T>): Promise<T> => {
+        steps.push({ title })
+        return body()
+      },
+    },
+  }
+}
+
+function makeFakeLocator(box: { x: number; y: number; width: number; height: number } | null) {
+  return {
+    page: () => ({ viewportSize: () => ({ width: 1280, height: 720 }) }),
+    boundingBox: async () => box,
+  } as unknown as Locator
+}
+
+describe('zoom() — marker contract', () => {
+  let env: ReturnType<typeof makeFakeTest>
+
+  beforeEach(() => {
+    env = makeFakeTest()
+    setupRecast(env.fakeTest)
+  })
+
+  it('pushes a zoom annotation and a marker step with JSON-parseable payload', async () => {
+    const locator = makeFakeLocator({ x: 128, y: 72, width: 256, height: 144 })
+
+    await zoom(locator, 1.5)
+
+    expect(env.annotations).toHaveLength(1)
+    expect(env.annotations[0]!.type).toBe('zoom')
+
+    // center = (128 + 256/2, 72 + 144/2) = (256, 144) → (256/1280, 144/720) = (0.2, 0.2)
+    const annPayload = JSON.parse(env.annotations[0]!.description!)
+    expect(annPayload).toEqual({ x: 0.2, y: 0.2, level: 1.5 })
+
+    expect(env.steps).toHaveLength(1)
+    expect(env.steps[0]!.title.startsWith(ZOOM_TITLE_PREFIX)).toBe(true)
+    const markerPayload = JSON.parse(env.steps[0]!.title.slice(ZOOM_TITLE_PREFIX.length))
+    expect(markerPayload).toEqual({ x: 0.2, y: 0.2, level: 1.5 })
+  })
+
+  it('uses default level 1.5 when omitted', async () => {
+    const locator = makeFakeLocator({ x: 0, y: 0, width: 100, height: 100 })
+
+    await zoom(locator)
+
+    const payload = JSON.parse(env.annotations[0]!.description!)
+    expect(payload.level).toBe(1.5)
+  })
+
+  it('does nothing when boundingBox returns null', async () => {
+    const locator = makeFakeLocator(null)
+
+    await zoom(locator, 2)
+
+    expect(env.annotations).toHaveLength(0)
+    expect(env.steps).toHaveLength(0)
+  })
+})
+
+describe('highlight() — marker contract', () => {
+  let env: ReturnType<typeof makeFakeTest>
+
+  beforeEach(() => {
+    env = makeFakeTest()
+    setupRecast(env.fakeTest)
+  })
+
+  it('pushes a highlight annotation and a marker step with the bounding box', async () => {
+    const locator = makeFakeLocator({ x: 10, y: 20, width: 300, height: 50 })
+
+    await highlight(locator, { color: '#FF0000', opacity: 0.6, duration: 2500 })
+
+    expect(env.annotations).toHaveLength(1)
+    expect(env.annotations[0]!.type).toBe('highlight')
+
+    const annPayload = JSON.parse(env.annotations[0]!.description!)
+    expect(annPayload).toMatchObject({
+      x: 10, y: 20, width: 300, height: 50,
+      color: '#FF0000', opacity: 0.6, duration: 2500,
+    })
+
+    expect(env.steps).toHaveLength(1)
+    const markerPayload = JSON.parse(env.steps[0]!.title.slice(HIGHLIGHT_TITLE_PREFIX.length))
+    expect(markerPayload).toEqual(annPayload)
+  })
+
+  it('does nothing when boundingBox returns null', async () => {
+    const locator = makeFakeLocator(null)
+
+    await highlight(locator)
+
+    expect(env.annotations).toHaveLength(0)
+    expect(env.steps).toHaveLength(0)
+  })
+})

--- a/tests/unit/helpers/narrate.test.ts
+++ b/tests/unit/helpers/narrate.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { TestInfo } from '@playwright/test'
+import {
+  narrate,
+  setupRecast,
+  NARRATE_TITLE_PREFIX,
+  NARRATE_HIDDEN_TITLE_PREFIX,
+} from '../../../src/helpers'
+
+type Annotation = { type: string; description?: string }
+type StepRecord = { title: string; bodyRan: boolean }
+
+function makeFakeTest(): {
+  info: TestInfo
+  steps: StepRecord[]
+  fakeTest: { info: () => TestInfo; step: <T>(t: string, b: () => T | Promise<T>) => Promise<T> }
+} {
+  const annotations: Annotation[] = []
+  const steps: StepRecord[] = []
+  const info = { annotations } as unknown as TestInfo
+  const fakeTest = {
+    info: () => info,
+    step: async <T,>(title: string, body: () => T | Promise<T>): Promise<T> => {
+      const rec: StepRecord = { title, bodyRan: false }
+      steps.push(rec)
+      const result = await body()
+      rec.bodyRan = true
+      return result
+    },
+  }
+  return { info, steps, fakeTest }
+}
+
+describe('narrate() — annotation contract (legacy report.json consumers)', () => {
+  let env: ReturnType<typeof makeFakeTest>
+
+  beforeEach(() => {
+    env = makeFakeTest()
+    setupRecast(env.fakeTest)
+  })
+
+  it('pushes voiceover + voiceover-hidden annotations even for undefined text', async () => {
+    await narrate(undefined, { hidden: true })
+
+    expect(env.info.annotations).toEqual([
+      { type: 'voiceover', description: '' },
+      { type: 'voiceover-hidden', description: '1' },
+    ])
+  })
+
+  it('pushes annotations for empty string (hidden=false default)', async () => {
+    await narrate('')
+
+    expect(env.info.annotations).toEqual([
+      { type: 'voiceover', description: '' },
+      { type: 'voiceover-hidden', description: '0' },
+    ])
+  })
+
+  it('pushes annotations for whitespace-only text and treats it as empty', async () => {
+    await narrate('   \n\t  ')
+
+    expect(env.info.annotations).toEqual([
+      { type: 'voiceover', description: '' },
+      { type: 'voiceover-hidden', description: '0' },
+    ])
+  })
+
+  it('does NOT write a trace marker step for empty text', async () => {
+    await narrate(undefined, { hidden: true })
+    await narrate('')
+
+    expect(env.steps).toEqual([])
+  })
+
+  it('preserves flat annotation order across mixed hidden/visible narrate calls', async () => {
+    // This is the exact pattern that demo-report-writer flat-index mapping
+    // depends on. Each narrate() must produce exactly two annotations in
+    // order (voiceover, voiceover-hidden), regardless of text content.
+    await narrate(undefined, { hidden: true }) // hidden login step
+    await narrate(undefined, { hidden: true }) // hidden login step
+    await narrate('Open the app', { hidden: true }) // hidden Given with text
+    await narrate('Type a query') // visible When
+    await narrate('Wait for result') // visible When
+
+    const types = env.info.annotations.map((a) => a.type)
+    expect(types).toEqual([
+      'voiceover', 'voiceover-hidden',
+      'voiceover', 'voiceover-hidden',
+      'voiceover', 'voiceover-hidden',
+      'voiceover', 'voiceover-hidden',
+      'voiceover', 'voiceover-hidden',
+    ])
+
+    const descriptions = env.info.annotations.map((a) => a.description)
+    expect(descriptions).toEqual([
+      '', '1',
+      '', '1',
+      'Open the app', '1',
+      'Type a query', '0',
+      'Wait for result', '0',
+    ])
+  })
+})
+
+describe('narrate() — trace marker emission', () => {
+  let env: ReturnType<typeof makeFakeTest>
+
+  beforeEach(() => {
+    env = makeFakeTest()
+    setupRecast(env.fakeTest)
+  })
+
+  it('writes a marker-prefixed test.step when text is present', async () => {
+    await narrate('Hello world')
+
+    expect(env.steps).toHaveLength(1)
+    expect(env.steps[0]!.title).toBe(`${NARRATE_TITLE_PREFIX}Hello world`)
+    expect(env.steps[0]!.bodyRan).toBe(true)
+  })
+
+  it('uses the hidden prefix when opts.hidden is true', async () => {
+    await narrate('Secret note', { hidden: true })
+
+    expect(env.steps).toHaveLength(1)
+    expect(env.steps[0]!.title).toBe(`${NARRATE_HIDDEN_TITLE_PREFIX}Secret note`)
+  })
+
+  it('detects @hidden in text and strips it from the marker', async () => {
+    await narrate('Some text @hidden')
+
+    expect(env.steps).toHaveLength(1)
+    expect(env.steps[0]!.title).toBe(`${NARRATE_HIDDEN_TITLE_PREFIX}Some text`)
+    expect(env.info.annotations).toEqual([
+      { type: 'voiceover', description: 'Some text' },
+      { type: 'voiceover-hidden', description: '1' },
+    ])
+  })
+})
+
+describe('narrate({ autoWait })', () => {
+  let env: ReturnType<typeof makeFakeTest>
+
+  beforeEach(() => {
+    env = makeFakeTest()
+    setupRecast(env.fakeTest)
+  })
+
+  it('does not wait when autoWait is omitted', async () => {
+    const t0 = Date.now()
+    await narrate('Hello world this is a longer line')
+    expect(Date.now() - t0).toBeLessThan(50)
+  })
+
+  it('waits an explicit number of milliseconds', async () => {
+    const t0 = Date.now()
+    await narrate('hi', { autoWait: 120 })
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeGreaterThanOrEqual(110)
+    expect(elapsed).toBeLessThan(400)
+  })
+
+  it('estimates wait time from character count when autoWait=true', async () => {
+    // 28 non-whitespace chars / 14 cps = 2000 ms
+    const text = 'abcdefghij abcdefghij abcdefgh'
+    const t0 = Date.now()
+    await narrate(text, { autoWait: { charactersPerSecond: 14, maxMs: 250 } })
+    // capped by maxMs
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeGreaterThanOrEqual(240)
+    expect(elapsed).toBeLessThan(500)
+  })
+})

--- a/website/content/docs/helpers/highlight.mdx
+++ b/website/content/docs/helpers/highlight.mdx
@@ -5,7 +5,9 @@ description: Highlight an element or specific text in the demo video with an ani
 
 ## What it does
 
-`highlight(locator)` captures an element's bounding box and stores it as a Playwright annotation. During video generation, the renderer draws an animated marker overlay that sweeps in from left to right, highlighting the element during the step's time window.
+`highlight(locator)` measures the element's viewport bounding box and emits a marker-prefixed `test.step()` directly into the Playwright trace zip. During video generation, [`subtitlesFromTrace()`](/docs/pipeline/subtitles) picks up these markers automatically and the renderer draws an animated overlay that sweeps in from left to right at the recorded position.
+
+You don't need to call `.textHighlight()` in the pipeline when using `highlight()` — the trace step is self-contained. You can still call `.textHighlight()` if you want to load highlights from an external `report.json` file instead.
 
 You can highlight an entire element or a specific substring within it.
 

--- a/website/content/docs/helpers/narrate.mdx
+++ b/website/content/docs/helpers/narrate.mdx
@@ -5,9 +5,9 @@ description: Attach voiceover narration text to a Playwright test step.
 
 ## What it does
 
-`narrate(text)` attaches voiceover text to the current test step as a Playwright annotation. During video generation, the pipeline reads these annotations to produce TTS audio and subtitles timed to each step.
+`narrate(text)` writes a marker-prefixed `test.step()` directly into the Playwright trace zip and attaches a `voiceover` annotation to `testInfo`. During video generation, [`subtitlesFromTrace()`](/docs/pipeline/subtitles) recovers each narration span from the recorded trace step — no separate report file or pipeline call is required.
 
-Call `narrate` from every step definition -- even when there is no doc string -- so the reporter can match annotations to steps by sequential index.
+Each narrate span starts at the helper's call site and runs until the next `narrate()` call (or the end of the trace). This is what `subtitlesFromTrace` turns into a `SubtitleEntry`.
 
 ## Usage
 
@@ -15,18 +15,43 @@ Call `narrate` from every step definition -- even when there is no doc string --
 import { narrate } from 'playwright-recast'
 
 // With narration text
-narrate('The user opens the dashboard to review analytics.')
+await narrate('The user opens the dashboard to review analytics.')
 
-// Without narration (still call it for index tracking)
-narrate(undefined)
+// Pad the test with the estimated time it takes to speak the line —
+// useful when running without TTS so the video has visual time for it.
+await narrate('Welcome to the new dashboard.', { autoWait: true })
+
+// No-op — pass undefined when a step has no narration.
+await narrate(undefined)
 ```
 
 ## Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `text` | `string \| undefined` | Voiceover text for this step. Pass `undefined` if no narration. |
-| `opts.hidden` | `boolean` | Mark the step as hidden (excluded from recording and SRT output). |
+| `text` | `string \| undefined` | Voiceover text for this step. Pass `undefined` to no-op. |
+| `opts.hidden` | `boolean` | Mark the step as hidden (excluded from subtitles). Detected automatically if `text` contains `@hidden`. |
+| `opts.autoWait` | `boolean \| number \| object` | Pause after recording the marker step for the approximate time the line takes to speak. See below. |
+
+## autoWait — visual time without TTS
+
+When running without TTS (e.g., live demos or local previews), the video needs enough visual time for each line. `autoWait` waits for an estimate based on `text` length:
+
+| Form | Behavior |
+|------|----------|
+| `true` | Estimate from non-whitespace characters / `NARRATE_DEFAULT_CPS` (14 ch/s ≈ 150 wpm). |
+| `number` | Wait exactly this many milliseconds. |
+| `{ charactersPerSecond, minMs, maxMs }` | Tune the estimate. |
+
+```typescript
+await narrate('Welcome to the new dashboard.', {
+  autoWait: { charactersPerSecond: 16, minMs: 1500, maxMs: 6000 },
+})
+```
+
+## Voiceover-driven freezes
+
+When the pipeline runs `voiceover()` and the synthesized audio for a narration is longer than the visual window between this narrate and the next, the renderer **holds the current frame** until the audio finishes. The frozen frame includes any active highlight/zoom overlay, and `clickEffect` sounds shift along with the timeline. You get audio-perfect sync without having to hand-tune `pace()` calls.
 
 ## Hiding steps
 
@@ -54,13 +79,13 @@ import { Given, When, Then } from './fixtures'
 import { narrate, pace } from 'playwright-recast'
 
 Given('the user opens the dashboard', async ({ page }, docString?: string) => {
-  narrate(docString)
+  await narrate(docString)
   await page.goto('/dashboard')
   await pace(page, 4000)
 })
 
 When('the user clicks the revenue chart', async ({ page }, docString?: string) => {
-  narrate(docString)
+  await narrate(docString)
   await page.click('.revenue-chart')
 })
 ```

--- a/website/content/docs/helpers/zoom.mdx
+++ b/website/content/docs/helpers/zoom.mdx
@@ -5,7 +5,9 @@ description: Zoom into a UI element during a test step for the demo video.
 
 ## What it does
 
-`zoom(locator, level)` captures an element's bounding box and stores viewport-relative coordinates as a Playwright annotation. During video generation, the renderer crops and scales the video to zoom into the recorded position during the step's time window.
+`zoom(locator, level)` measures the element's center as viewport-relative coordinates and emits a marker-prefixed `test.step()` directly into the Playwright trace zip. During video generation, [`subtitlesFromTrace()`](/docs/pipeline/subtitles) picks up these markers automatically and attaches the zoom to the currently-active subtitle — no separate `.enrichZoomFromReport()` call needed.
+
+The zoom **starts at the helper's call site** (not at the start of the surrounding narration) and runs until the end of the subtitle, so the camera kicks in only once the target is visible.
 
 ## Usage
 
@@ -27,8 +29,9 @@ await zoom(sidebar, 1.3)
 
 1. Gets the element's bounding box via `locator.boundingBox()`
 2. Computes the center as viewport-relative fractions (0.0--1.0)
-3. Stores `{ x, y, level }` as a `zoom` annotation on the current test
-4. During rendering, `enrichZoomFromReport()` reads these annotations and applies crop-and-scale zoom with smooth easing transitions
+3. Writes a marker-prefixed `test.step()` carrying `{ x, y, level }` into the trace zip (and pushes a matching `zoom` annotation onto `testInfo` for legacy reporters)
+4. `subtitlesFromTrace()` finds the marker step at parse time and attaches the zoom to whichever subtitle covers the call site
+5. The renderer applies the crop-and-scale zoom from the call-site time until the end of that subtitle, with smooth easing transitions
 
 ## Zoom coordinates
 

--- a/website/content/docs/pipeline/render.mdx
+++ b/website/content/docs/pipeline/render.mdx
@@ -23,6 +23,7 @@ await Recast
 | `resolution` | `string` | `'1080p'` | Output resolution: `'720p'`, `'1080p'`, `'4k'` |
 | `fps` | `number` | `30` | Output frame rate |
 | `burnSubtitles` | `boolean` | `false` | Burn subtitles into the video |
+| `embedSubtitles` | `boolean \| object` | `false` | Mux subtitles as a soft (toggleable) track inside the container |
 | `subtitleStyle` | `object` | default ffmpeg | Subtitle appearance configuration |
 
 ## Output with `.toFile()`
@@ -37,6 +38,28 @@ After configuring the render, call `.toFile()` to execute the pipeline and write
 ## Subtitle burn-in
 
 Set `burnSubtitles: true` to render subtitles directly into the video frames. Without `subtitleStyle`, ffmpeg's default SRT rendering is used.
+
+## Embedded (soft) subtitle track
+
+Set `embedSubtitles: true` to mux subtitles as a toggleable track inside the container. The viewer can switch them on/off in their player. Works for both `mp4` (mov_text) and `webm` (webvtt).
+
+```typescript
+.render({
+  format: 'mp4',
+  embedSubtitles: true,                        // language: 'eng', title: 'Subtitles'
+})
+
+.render({
+  format: 'mp4',
+  embedSubtitles: { language: 'ger', title: 'Deutsch', default: true },
+})
+```
+
+`embedSubtitles` and `burnSubtitles` can be combined — viewers see the burned-in text regardless and can also toggle the embedded track.
+
+## Voiceover-driven freezes
+
+When the pipeline includes `voiceover()` and the synthesized audio for a narration is longer than its visual window, the renderer **holds the current frame** until the audio finishes. The frozen frame keeps any active highlight or zoom overlay; click sounds shift along with the timeline. No configuration required — this happens automatically based on the `freezes` emitted by the voiceover stage.
 
 ### Subtitle style options
 

--- a/website/content/docs/pipeline/subtitles.mdx
+++ b/website/content/docs/pipeline/subtitles.mdx
@@ -32,13 +32,19 @@ Navigate to the analytics dashboard.
 
 ## Generate from trace
 
-Auto-generate subtitles from BDD step titles found in the trace:
+Auto-generate subtitles from marker steps and BDD step titles found in the trace:
 
 ```typescript
 .subtitlesFromTrace()
 ```
 
-This reads the step names from your Playwright BDD test and uses them as subtitle text. Works with [playwright-bdd](https://github.com/nickkuprin/playwright-bdd) Gherkin steps.
+`subtitlesFromTrace()` picks up three sources of data from the recorded trace:
+
+1. **`narrate()` marker steps** — when present, one subtitle per narration, spanning from each `narrate()` call to the next.
+2. **`highlight()` marker steps** — bounding boxes the renderer turns into animated marker overlays.
+3. **`zoom()` marker steps** — attached to whichever subtitle covers the call site, so the camera kicks in at the right moment.
+
+If no `narrate()` steps are present, it falls back to using BDD step titles (e.g., `Given the user opens the dashboard`) — useful for [playwright-bdd](https://github.com/nickkuprin/playwright-bdd) projects that don't use the helpers.
 
 ## Generate from actions
 

--- a/website/content/docs/pipeline/text-highlight.mdx
+++ b/website/content/docs/pipeline/text-highlight.mdx
@@ -3,22 +3,36 @@ title: Text Highlight
 description: Animated marker overlays on text elements in the video.
 ---
 
-The `.textHighlight()` stage renders animated marker overlays on text elements. A swipe-in animation reveals the highlight left-to-right, then the overlay disappears at the subtitle boundary.
+Animated marker overlays on text elements. A swipe-in animation reveals the highlight left-to-right, then the overlay disappears at the subtitle boundary.
 
-## Basic usage
+The renderer accepts highlight events from two sources:
+
+1. **Trace step markers (default).** When the test uses the [`highlight()`](/docs/helpers/highlight) helper, each call writes a marker-prefixed `test.step()` into the trace zip. `subtitlesFromTrace()` reads these at parse time and the renderer draws the overlays automatically — **no `.textHighlight()` call required**.
+2. **External `report.json`.** Calling `.textHighlight()` loads highlights from a `report.json` file sitting next to the trace, useful when your highlights come from a non-Playwright source.
+
+## Helper-driven (recommended)
 
 ```typescript
 await Recast
   .from('./traces')
   .parse()
-  .textHighlight()
+  .subtitlesFromTrace()       // picks up highlight markers automatically
+  .render({ format: 'mp4' })
+  .toFile('demo.mp4')
+```
+
+## Loading from report.json
+
+```typescript
+await Recast
+  .from('./traces')
+  .parse()
+  .textHighlight()            // loads from <trace>/report.json
   .render({ format: 'mp4' })
   .toFile('demo.mp4')
 ```
 
 ## How it works
-
-Text highlight reads highlight data from `report.json` automatically. Each highlight specifies a bounding box and timing, and the renderer draws an animated marker overlay at that position.
 
 The swipe-in animation reveals the highlight from left to right. The highlight end time is clamped to the subtitle boundary so overlays do not overflow into the next step.
 


### PR DESCRIPTION
## Summary

  Make the `narrate()`, `highlight()`, and `zoom()` step helpers self-contained: each helper now writes a marker-prefixed `test.step()` directly into the Playwright trace zip, and `subtitlesFromTrace()` recovers everything (narration spans, highlight overlays, per-subtitle zoom) from the trace. No `report.json`, no extra pipeline calls — drop the helpers into your test
   and the pipeline does the rest.

  Also adds two oft-requested knobs and fixes audio sync for long narrations.

  ## What's new

  - **Self-contained `narrate()` / `highlight()` / `zoom()`** — Each helper emits a marker-prefixed `test.step()` into the trace zip. `subtitlesFromTrace()` extracts narration spans, highlight overlays, and per-subtitle zoom from the recorded marker steps. The legacy `.textHighlight()` and `.enrichZoomFromReport()` pipeline stages remain available for non-Playwright
  highlight sources.
  - **Voiceover-driven freezes** — When a narration's TTS audio is longer than its visual window, the renderer holds the current frame until the audio finishes. Overlays freeze with the frame, click sounds shift to match — audio-perfect sync without hand-tuning `pace()` calls.
  - **`narrate({ autoWait })`** — Pads the test by an estimated speaking time using a character-based heuristic (`NARRATE_DEFAULT_CPS = 14`). Accepts `true`, an explicit ms count, or `{ charactersPerSecond, minMs, maxMs }`. Useful when running without TTS so the recorded video has natural visual time for each line.
  - **`render({ embedSubtitles })`** — Muxes a soft (toggleable) subtitle track into the container: `mov_text` for `mp4`, `webvtt` for `webm`. Accepts `true` for defaults or `{ language, title, default }` to customize. Composes with `burnSubtitles`.

  ## Behavior change

  - **Zoom marker start time** — Zoom now starts at the `zoom()` call site (in-window) rather than at the parent narration's start, so the camera kicks in only once the target is visible. The same shifts that move `subtitle.startMs` (blank-trim, voiceover `timeShift`) now also move `zoom.startMs` / `zoom.endMs`.

  ## Example
  
  ```typescript
  import { narrate, highlight, zoom, pace } from 'playwright-recast'

  When('the user reviews KPI', async ({ page }, docString?: string) => {
    await narrate(docString, { autoWait: true })            // pad test by estimated speak time
    await highlight(page.locator('h2'), { text: 'Revenue' }) // auto-picked up by subtitlesFromTrace
    await zoom(page.locator('.kpi-card'), 1.3)               // starts at this call site, not at narration start
  })
```

  ```typescript
  await Recast
    .from('./traces')
    .parse()
    .subtitlesFromTrace()                                    // picks up narrate/highlight/zoom markers automatically
    .voiceover(provider)                                     // overflow frames freeze automatically
    .render({ embedSubtitles: true, burnSubtitles: true })
    .toFile('demo.mp4')
```
