### PR TITLE
feat(qwen)!: add Qwen3-TTS voice provider with clone + design modes

### DIFF
--- a/.claude/playwright-recast/skills/recast-guide/SKILL.md
+++ b/.claude/playwright-recast/skills/recast-guide/SKILL.md
@@ -120,6 +120,50 @@ import { ElevenLabsProvider } from 'playwright-recast/providers/elevenlabs'
 ElevenLabsProvider({ voiceId: 'onwK4e9ZLuTAKqWW03F9', modelId: 'eleven_multilingual_v2' })
 ```
 
+**Qwen3-TTS** (local, CUDA GPU + Python sidecar):
+```typescript
+import { QwenTtsProvider } from 'playwright-recast/providers/qwen'
+
+// Clone an existing voice from a WAV/MP3 sample.
+QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './my-voice.wav',
+  refText: 'Transcript of the voice sample.',
+  language: 'English',
+  cacheAudio: true,
+})
+
+// Or design a voice from a prompt.
+QwenTtsProvider({
+  mode: 'design',
+  voiceDescription: 'Calm, steady male voice.',
+  refText: 'Sample line the model will speak in the designed voice.',
+  language: 'English',
+  cacheAudio: true,
+  cacheVoiceDesign: true,
+})
+```
+
+Setup — PyTorch + flash-attn is ~5–8 GB, so recommend **one shared venv reused across projects** pointed at via `pythonBin`:
+
+```bash
+python3 -m venv ~/.venvs/qwen-tts
+~/.venvs/qwen-tts/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+```
+
+```typescript
+QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './ref.wav',
+  refText: 'Sample transcript.',
+  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+})
+```
+
+Alternatives: `uv venv` + `uv pip install` (hardlinks from a global wheel store — per-project `.venv` becomes nearly free); or a per-project `.venv` for full isolation (costs ~5–8 GB/project without `uv`); or a conda env. Whichever you pick, pass the venv's `bin/python3` (absolute path) as `pythonBin` so no shell activation is needed.
+
+Needs a CUDA GPU (~4–8 GB VRAM) and `HF_TOKEN` if the chosen weights are gated. Failures surface as `QwenSidecarError` with a `stage` field (`init` / `design` / `clone`).
+
 ## playwright-bdd Integration
 
 Step helpers for BDD test definitions. Each helper (`narrate`, `highlight`, `zoom`) writes a marker-prefixed `test.step()` directly into the trace zip — `subtitlesFromTrace()` picks them all up automatically. No separate `report.json` or extra pipeline calls required.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ reports/
 
 # npm auth
 .npmrc
+/.idea
+/.venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.17.0 (2026-05-22)
+
+### Features
+
+- **`QwenTtsProvider`** — Local TTS via Alibaba's Qwen3-TTS family with clone and design modes. Spawns a Python sidecar; opt-in disk caching for both synthesized audio (MP3) and the design reference WAV. See README for setup.
+
+### Breaking changes
+
+- **`TtsProvider.synthesize` is now batch-first** — Signature changes from `synthesize(text: string, options?) => Promise<AudioSegment>` to `synthesize(texts: string[], options?) => Promise<AudioSegment[]>`. The provider receives the full subtitle text array and returns one segment per input, in order. Built-in providers (OpenAI, ElevenLabs, Polly) get free concurrency from internal `Promise.all` fan-out — no caller change required. Custom-provider authors must update their `synthesize` to accept an array.
+- **`AudioSegment.data` is replaced by `AudioSegment.path`** — Synthesized audio is now written to a file on disk and the segment carries the path instead of an in-memory `Buffer`. The new `TtsOptions.workDir` field tells the provider where to write outputs (caller — the pipeline — owns cleanup). Custom-provider authors must write their audio to disk and return the path.
+
+### Migration
+
+If you have a custom `TtsProvider`, wrap your existing per-text logic:
+
+```ts
+synthesize(texts: string[], opts) {
+  const dir = opts?.workDir ?? os.tmpdir()
+  return Promise.all(texts.map(async (text) => {
+    const buf = await mySingleTextSynthesis(text)
+    const p = path.join(dir, `mine-${crypto.randomUUID()}.mp3`)
+    await fs.promises.writeFile(p, buf)
+    return { path: p, durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } }
+  }))
+}
+```
+
 ## 0.16.0 (2026-05-22)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -357,6 +357,79 @@ npm install @aws-sdk/client-polly
 
 Resolves credentials from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and optional `AWS_SESSION_TOKEN`), shared config, or — preferred on AWS — an attached IAM role.
 
+### Qwen3-TTS (local, GPU)
+
+Local TTS backed by Alibaba's Qwen3-TTS models. Two modes:
+
+- **Clone** — synthesize text in the voice of a reference WAV/MP3.
+- **Design** — synthesize text in a voice described by a prompt.
+
+```typescript
+import { QwenTtsProvider } from 'playwright-recast/providers/qwen'
+
+// Clone an existing voice
+.voiceover(QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './my-voice.wav',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  language: 'English',
+  cacheAudio: true,
+}))
+
+// Design a voice from a description
+.voiceover(QwenTtsProvider({
+  mode: 'design',
+  voiceDescription: 'A clear, steady male voice with a calm and even tone.',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  language: 'English',
+  cacheAudio: true,
+  cacheVoiceDesign: true,
+}))
+```
+
+The provider spawns a Python sidecar (PyTorch + `qwen-tts` + `flash-attn`)
+once per pipeline run. The deps are heavy (~5–8 GB on disk for PyTorch +
+flash-attn), so the recommended setup is **one shared venv reused across
+projects**, pointed at via `pythonBin`:
+
+```bash
+python3 -m venv ~/.venvs/qwen-tts
+~/.venvs/qwen-tts/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+```
+
+```typescript
+.voiceover(QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './my-voice.wav',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+}))
+```
+
+Absolute `pythonBin` means no shell activation required — works in CI,
+cron jobs, and IDE runners alike.
+
+**Alternatives:**
+
+- **`uv`** (Astral): `uv venv ~/.venvs/qwen-tts && uv pip install -p ~/.venvs/qwen-tts/bin/python -r .../requirements.txt`. `uv` hardlinks from a global wheel store, so even a per-project `.venv` is nearly free on disk.
+- **Per-project `.venv`**: `python3 -m venv .venv` and `pythonBin: '.venv/bin/python3'`. Cleanest isolation; costs ~5–8 GB per project unless you're using `uv`.
+- **Conda**: works the same way — point `pythonBin` at the env's interpreter.
+
+Requires a CUDA-capable GPU (~4–8 GB VRAM depending on model). `HF_TOKEN` in
+the environment if the chosen weights are gated.
+
+**Caching** — both flags default off:
+
+| Flag | What it caches | Hash includes |
+|---|---|---|
+| `cacheAudio` | Per-segment MP3s at `cacheDir/audio/<hash>.mp3` | target text, refText, ref-audio fingerprint, language, model, dtype |
+| `cacheVoiceDesign` (design mode only) | The design WAV at `cacheDir/design/<hash>.wav` | description, refText, language, designModel, dtype |
+
+`cacheDir` defaults to `./.recast-cache/voice/`. The cache grows unbounded;
+manage it yourself.
+
+**Defaults:** `cloneModel: 'Qwen/Qwen3-TTS-12Hz-0.6B-Base'`, `designModel: 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign'`, `device: 'cuda:0'`, `dtype: 'bfloat16'`, `language: 'English'`.
+
 ### Loudness normalization
 
 TTS providers (especially ElevenLabs on `eleven_multilingual_v2` + non-English languages) can deliver segments at wildly different levels — one line at −16 LUFS, the next at −32 LUFS. Enable opt-in per-segment normalization to fix it:

--- a/docs/superpowers/specs/2026-05-22-qwen-voice-provider-design.md
+++ b/docs/superpowers/specs/2026-05-22-qwen-voice-provider-design.md
@@ -1,0 +1,444 @@
+# Qwen3-TTS Voice Provider — Design
+
+**Status:** Draft
+**Date:** 2026-05-22
+**Author:** Andreas Berger
+
+## Summary
+
+Add a local TTS provider backed by Alibaba's Qwen3-TTS family (`Qwen3-TTS-12Hz-0.6B-Base` for voice cloning, `Qwen3-TTS-12Hz-1.7B-VoiceDesign` for voice design). Two modes:
+
+- **Clone mode** — user supplies a reference WAV/MP3 + the text spoken in it. The provider synthesizes target text in that voice.
+- **Design mode** — user supplies a voice description (free-form prompt) + a reference text. The provider first generates a reference WAV from the description, then clones target text against it.
+
+A Python sidecar runs the model (PyTorch + CUDA + `flash-attn` + `qwen-tts`); the TypeScript provider drives it over stdin/stdout JSON. Generated audio and the design reference WAV are cached on disk (opt-in flags) so repeated runs with the same inputs skip the model entirely.
+
+This work also changes the `TtsProvider` contract to be batch-first and path-based across all providers (OpenAI / ElevenLabs / Polly / Qwen). This is a breaking change that ships in the same release.
+
+## Motivation
+
+`playwright-recast` currently supports three cloud TTS providers. Qwen3-TTS adds:
+
+- **Voice control the cloud providers don't expose** — clone an arbitrary voice from a short reference sample, or design a voice from a textual description.
+- **Offline operation** — no API key, no network, no per-character cost. Important for repeated iteration on a single demo video.
+- **Determinism** — sampling is disabled by default; same inputs produce the same output, which makes the audio cache reliable.
+
+The Qwen model load cost (~10-30s) only matters on the first cache miss; subsequent iterations on the same script are instant.
+
+## Public API
+
+### Provider factory
+
+```ts
+import { Recast, QwenTtsProvider } from 'playwright-recast'
+
+// Clone mode
+.voiceover(QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './my-voice.wav',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  language: 'English',
+  cacheAudio: true,
+}))
+
+// Design mode
+.voiceover(QwenTtsProvider({
+  mode: 'design',
+  voiceDescription: 'A clear, steady male voice with a calm and even tone throughout.',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  language: 'English',
+  cacheAudio: true,
+  cacheVoiceDesign: true,
+}))
+```
+
+### Config types
+
+```ts
+interface QwenTtsCommonConfig {
+  refText: string                                       // required in both modes
+  language?: string                                     // Qwen-native name (default 'English')
+  cloneModel?: string                                   // default 'Qwen/Qwen3-TTS-12Hz-0.6B-Base'
+  cacheDir?: string                                     // default './.recast-cache/voice'
+  cacheAudio?: boolean                                  // default false
+  pythonBin?: string                                    // default 'python3'
+  device?: string                                       // default 'cuda:0'
+  dtype?: 'bfloat16' | 'float16' | 'float32'            // default 'bfloat16'
+}
+
+interface QwenCloneModeConfig extends QwenTtsCommonConfig {
+  mode: 'clone'
+  voiceSample: string                                   // path to WAV/MP3
+}
+
+interface QwenDesignModeConfig extends QwenTtsCommonConfig {
+  mode: 'design'
+  voiceDescription: string
+  designModel?: string                                  // default 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign'
+  cacheVoiceDesign?: boolean                            // default false
+}
+
+export type QwenTtsProviderConfig = QwenCloneModeConfig | QwenDesignModeConfig
+```
+
+The discriminated union enforces required fields at compile time. Construction-time validation re-checks: missing `refText`, both `voiceSample` and `voiceDescription` set, or neither set, all throw immediately.
+
+`HF_TOKEN` is read from the environment by the sidecar (not part of config). Qwen sampling parameters (`do_sample=False`, `top_p=1.0`, `num_beams=1`) are hard-coded for determinism.
+
+### Public exports
+
+Added to `src/index.ts`:
+
+```ts
+export { QwenTtsProvider } from './voiceover/providers/qwen.js'
+export type { QwenTtsProviderConfig } from './voiceover/providers/qwen.js'
+```
+
+## Breaking changes to the `TtsProvider` contract
+
+The Qwen model batches efficiently on the GPU when given all texts in one call. The current `synthesize(text)` shape forces N round-trips. We switch the contract to be batch-first and path-based:
+
+```ts
+// src/types/voiceover.ts
+
+export interface AudioSegment {
+  path: string                                          // was: data: Buffer
+  durationMs: number                                    // 0 if unknown; processor probes with ffprobe
+  format: { sampleRate: number; channels: number; codec: string }
+}
+
+export interface TtsOptions {
+  voice?: string
+  model?: string
+  languageCode?: string
+  speed?: number
+  format?: 'mp3' | 'wav' | 'opus' | 'pcm'
+  workDir?: string                                      // NEW: where the provider should write outputs
+}
+
+export interface TtsProvider {
+  readonly name: string
+  synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]>  // batch + path-based
+  estimateDurationMs(text: string, options?: TtsOptions): number
+  isAvailable(): Promise<boolean>
+  dispose(): Promise<void>
+}
+```
+
+### Migration shape for cloud providers
+
+Each cloud provider wraps its per-text call with `Promise.all`, writes the bytes to `opts.workDir`, and returns paths:
+
+```ts
+synthesize(texts: string[], opts) {
+  const dir = opts?.workDir ?? os.tmpdir()
+  return Promise.all(texts.map(async (text, i) => {
+    const buf = await fetchSingleText(text)
+    const p = path.join(dir, `${this.name}-${crypto.randomUUID()}.mp3`)
+    await fs.promises.writeFile(p, buf)
+    return { path: p, durationMs: 0, format: { sampleRate: ..., channels: 1, codec: 'mp3' } }
+  }))
+}
+```
+
+OpenAI, ElevenLabs, and Polly all get free concurrency from this change (they previously synthesized strictly sequentially).
+
+### Processor refactor
+
+`src/voiceover/voiceover-processor.ts` calls the provider once up front:
+
+```ts
+const texts = trace.subtitles.map(s => s.ttsText ?? s.text)
+const audios = await provider.synthesize(texts, { workDir: tmpDir })
+
+for (let si = 0; si < trace.subtitles.length; si++) {
+  const subtitle = trace.subtitles[si]!
+  const audio = audios[si]!
+  // existing silence-padding, normalize, concat logic but reading from audio.path
+  // instead of writeFileSync(rawPath, audio.data)
+}
+```
+
+The `timeShift` mutation still works because we iterate subtitles in order with all durations already known after the batch returns. `normalizeLoudness(rawPath, segPath, ...)` already takes paths and is unaffected.
+
+## Cache layout and hashing
+
+### Directory structure
+
+Under `cacheDir` (default `./.recast-cache/voice/`):
+
+```
+.recast-cache/voice/
+├── design/
+│   └── <designHash>.wav            # one per unique design input set
+└── audio/
+    └── <audioHash>.mp3             # one per unique target text + reference voice
+```
+
+The cache directory is created lazily — if both cache flags are off, nothing is written.
+
+### Design hash (design mode only)
+
+```
+designHash = sha256(JSON.stringify({
+  kind: 'design',
+  voiceDescription,
+  refText,
+  language,
+  designModel,
+  dtype,
+}))
+```
+
+### Audio hash (per target text)
+
+```
+audioHash = sha256(JSON.stringify({
+  kind: 'audio',
+  text,                            // the target text being synthesized
+  language,
+  cloneModel,
+  dtype,
+  refText,
+  refAudioFingerprint,
+}))
+```
+
+`refAudioFingerprint` is computed once per provider instance:
+
+- **Clone mode** — `sha256(fileContents(voiceSample))`. Hash of the user's reference WAV/MP3 bytes.
+- **Design mode** — `designHash` (above). Because the reference is itself derived deterministically from the design inputs, hashing those inputs is equivalent to hashing the (uncomputed) reference WAV bytes.
+
+Consequence: in design mode, changing `voiceDescription` invalidates the design WAV AND every cached audio that referenced it. This is correct — the audio cache should not survive a voice change.
+
+### Cache flag behaviour
+
+- `cacheAudio: false` — audio is always regenerated. The provider writes the (converted) MP3 to a temp file under the processor's `workDir` instead of `cacheDir/audio/`. Cache reads are also skipped.
+- `cacheVoiceDesign: false` — design WAV is always regenerated. Written to a temp file under `workDir`. Cache reads skipped. Cleaned up at end of `synthesize()`.
+- Both flags default to `false`. Cache directory is not created unless at least one flag is on.
+
+### Output format
+
+- The sidecar produces WAV (Qwen native via `soundfile.write`).
+- The provider converts each clone WAV to MP3 (single ffmpeg pass) before writing to the audio cache path or processor temp path. MP3 because the rest of `voiceover-processor.ts` is MP3-locked (`-c copy` concat, MP3 silence generator). Conversion is fast and happens only on cache miss.
+- Design WAV is kept as-is in `cacheDir/design/` — it is an input to clone, not a pipeline segment.
+- Making the cache format configurable is out of scope until the processor is made format-aware.
+
+## Sidecar IPC
+
+### Location and packaging
+
+```
+src/voiceover/providers/qwen-sidecar/
+├── sidecar.py
+├── requirements.txt          # torch, numpy, psutil, qwen-tts, soundfile, flash-attn
+└── README.md                 # install + GPU requirements
+```
+
+The Python script ships inside the npm package. The provider invokes it as `${pythonBin} <abs-path-to>/sidecar.py`. Users must install the Python dependencies separately into whatever environment `pythonBin` resolves to.
+
+### Protocol
+
+JSON over stdin/stdout, one batch per spawn. Node writes the request as a single line, closes stdin, reads stdout until EOF, waits for exit.
+
+**Request** (Node → Python stdin):
+
+```json
+{
+  "workDir": "/abs/path/.recast-tmp/qwen-xxx",
+  "device": "cuda:0",
+  "dtype": "bfloat16",
+  "language": "English",
+  "cloneModel": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+  "design": {
+    "designModel": "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+    "voiceDescription": "A clear, steady male voice...",
+    "refText": "Welcome! In this screencast..."
+  },
+  "clone": {
+    "refAudio": "/abs/path/to/ref.wav",
+    "refText": "Welcome! In this screencast...",
+    "texts": ["First we need to login", "Then enter the query"]
+  }
+}
+```
+
+- `design` is omitted when the design WAV is already cached or when in clone mode.
+- `clone.refAudio` is the design output path when `design` is present, otherwise the cached design WAV, otherwise the user's `voiceSample`. Node chooses; the sidecar uses what it receives.
+- `clone.texts` contains only cache misses. Node filters out hits before invoking the sidecar.
+- If both `design` is absent and `clone.texts` is empty, **Node never spawns the sidecar.**
+
+**Response on success** (Python stdout, single line JSON):
+
+```json
+{
+  "ok": true,
+  "design": { "path": "/abs/.recast-tmp/qwen-xxx/design.wav" },
+  "clone":  [
+    { "path": "/abs/.recast-tmp/qwen-xxx/clone-0.wav" },
+    { "path": "/abs/.recast-tmp/qwen-xxx/clone-1.wav" }
+  ]
+}
+```
+
+- `design` key present only when the request had a `design` block.
+- `clone` array aligns 1:1 with request `clone.texts` order.
+- The sidecar owns the naming convention inside `workDir`; Node consumes the returned paths.
+
+**Response on failure** (single line JSON, then exit 1):
+
+```json
+{
+  "ok": false,
+  "stage": "init" | "design" | "clone",
+  "error": "human-readable message",
+  "traceback": "python traceback string"
+}
+```
+
+Node throws `QwenSidecarError` with the stage and message. Full traceback is also forwarded to stderr.
+
+### Sidecar internals
+
+```python
+import json, sys, traceback
+
+stage = "init"
+results = {"ok": True}
+
+try:
+    # Anything that can fail before model work counts as 'init':
+    #   - missing Python deps (ImportError on torch / qwen_tts / flash_attn / soundfile)
+    #   - malformed request JSON from Node
+    import soundfile as sf
+    import torch
+    from qwen_tts import Qwen3TTSModel
+    req = json.loads(sys.stdin.read())
+
+    if "design" in req:
+        stage = "design"
+        d = req["design"]
+        m = Qwen3TTSModel.from_pretrained(
+            d["designModel"],
+            device_map=req["device"],
+            dtype=getattr(torch, req["dtype"]),
+            attn_implementation="flash_attention_2",
+        )
+        wavs, sr = m.generate_voice_design(
+            text=[d["refText"]],
+            language=req["language"],
+            do_sample=False, top_p=1.0, num_beams=1,
+            instruct=[d["voiceDescription"]],
+        )
+        design_path = f"{req['workDir']}/design.wav"
+        sf.write(design_path, wavs[0], sr)
+        results["design"] = {"path": design_path}
+        del m
+        torch.cuda.empty_cache()
+
+    if req.get("clone", {}).get("texts"):
+        stage = "clone"
+        c = req["clone"]
+        m = Qwen3TTSModel.from_pretrained(
+            req["cloneModel"],
+            device_map=req["device"],
+            dtype=getattr(torch, req["dtype"]),
+            attn_implementation="flash_attention_2",
+        )
+        wavs, sr = m.generate_voice_clone(
+            text=c["texts"],
+            language=req["language"],
+            ref_audio=c["refAudio"],
+            ref_text=c["refText"],
+        )
+        clone_results = []
+        for i, wav in enumerate(wavs):
+            p = f"{req['workDir']}/clone-{i}.wav"
+            sf.write(p, wav, sr)
+            clone_results.append({"path": p})
+        results["clone"] = clone_results
+
+    print(json.dumps(results))
+except Exception as e:
+    print(json.dumps({"ok": False, "stage": stage, "error": str(e), "traceback": traceback.format_exc()}))
+    sys.exit(1)
+```
+
+The design model is released before the clone model loads to keep VRAM low.
+
+### Node-side post-processing
+
+For each call to `provider.synthesize(texts, { workDir })`:
+
+1. Compute `audioHash` for every text. If `cacheAudio` is on, partition into `hits` and `misses` against `cacheDir/audio/`.
+2. Resolve `refAudio`:
+   - Clone mode → `config.voiceSample`.
+   - Design mode → compute `designHash`. If `cacheVoiceDesign` is on and `cacheDir/design/<designHash>.wav` exists, use it. Otherwise schedule a `design` block in the request.
+3. If `misses.length === 0` AND no design request → skip the sidecar entirely. Return cache-hit paths.
+4. Otherwise create a sidecar-local `workDir` under the processor's `workDir` (e.g., `${processorTmp}/qwen-${uuid}`). Spawn the sidecar. Write request + newline to stdin. Read stdout. Wait for exit.
+5. If `response.design` present:
+   - `cacheVoiceDesign: true` → move WAV to `cacheDir/design/<designHash>.wav`.
+   - `cacheVoiceDesign: false` → leave in sidecar `workDir`; it gets cleaned up at end of `synthesize()`.
+6. For each clone result, ffmpeg-convert WAV → MP3 into either `cacheDir/audio/<audioHash>.mp3` (if `cacheAudio`) or `${processorWorkDir}/qwen-${uuid}.mp3` (if not).
+7. Build the final `AudioSegment[]` array in input order: cache hits at their cached paths, fresh misses at the just-written MP3 paths.
+8. Delete the sidecar-local `workDir` (cleanup).
+
+### Failure modes Node handles explicitly
+
+- `pythonBin` missing → `Error: Could not spawn '${pythonBin}'. Install Python 3 or set pythonBin in config.`
+- ImportError on `qwen_tts` / `torch` / `flash_attn` → wrapped error with installation instructions pointing to `requirements.txt`.
+- Non-zero exit with parseable JSON → `QwenSidecarError(stage, error)`.
+- Non-zero exit without parseable JSON → raw stderr in the error message.
+- Sidecar deadlock / hung process → no explicit timeout in v1; user kills the parent process. Optional `sidecarTimeoutMs` deferred until needed.
+
+## Testing strategy
+
+| Layer | What | How |
+|---|---|---|
+| Unit — hashing | `audioHash` / `designHash` deterministic, sensitive to each input | Vitest |
+| Unit — config validation | Mode/refText invariants throw at construction | Vitest |
+| Unit — request builder | Request shape correct for (miss-only, hit-only, mixed, design-needed, design-cached) | Vitest snapshot |
+| Unit — response parser | Success and error responses parse correctly; `QwenSidecarError` carries the stage | Vitest |
+| Integration — stub sidecar | `tests/fixtures/qwen-stub.py` reads the request and writes short silence WAVs to the response paths. Exercises full provider flow (cache write, cache hit on second call, WAV→MP3 conversion) without GPU or model downloads. | Vitest |
+| Integration — processor batch refactor | Updated voiceover tests; new test that confirms `workDir` flows from processor → provider | Vitest |
+| Manual — real model | `tests/manual/qwen-real.test.ts` gated by `RECAST_RUN_QWEN_TESTS=1`. Documented in CONTRIBUTING. Not in CI. | Manual |
+
+The stub-sidecar pattern is what makes the entire Node side testable in CI.
+
+## Out of scope (v1)
+
+- **CLI integration.** No `--provider qwen` flags. Wider configuration surface than CLI flags express well.
+- **MCP integration.** `RECAST_TTS_PROVIDER=qwen` is not auto-detected. Users can still hand the provider to `Recast` programmatically.
+- **Streaming / progress callbacks.** No incremental progress API. Future addition via optional `onProgress` on `TtsOptions`.
+- **WAV cache format.** MP3 only.
+- **Cache eviction / size limits.** Cache grows unbounded; user manages it. Noted in README.
+- **`languageCode` BCP-47 mapping.** `language: 'English'` only (Qwen native string). Mapping `'en' → 'English'` etc. deferred.
+- **Sidecar timeout / heartbeat.** No explicit `sidecarTimeoutMs`. Deferred.
+
+## Rollout
+
+- **Version:** `0.15.x` → `0.16.0`. Breaking `TtsProvider` / `AudioSegment` change; minor bump under semver `0.x` convention.
+- **CHANGELOG:** new provider section, the `synthesize(texts)` batch contract, the `AudioSegment.path` change, the per-provider migration snippet.
+- **README:** new "Qwen3-TTS" subsection under "TTS Providers" — both modes, Python install instructions, GPU requirements, cache flag explanation.
+- **Peer dependencies:** none added on the Node side. Python deps live in `sidecar/requirements.txt`, not enforced by npm.
+
+## File list
+
+```
+src/voiceover/providers/qwen.ts                          (new — provider)
+src/voiceover/providers/qwen-sidecar/sidecar.py          (new)
+src/voiceover/providers/qwen-sidecar/requirements.txt    (new)
+src/voiceover/providers/qwen-sidecar/README.md           (new)
+src/voiceover/providers/openai.ts                        (refactor to batch + path)
+src/voiceover/providers/elevenlabs.ts                    (refactor to batch + path)
+src/voiceover/providers/polly.ts                         (refactor to batch + path)
+src/voiceover/voiceover-processor.ts                     (refactor to batch call)
+src/types/voiceover.ts                                   (AudioSegment + TtsProvider)
+src/index.ts                                             (export QwenTtsProvider + type)
+tests/fixtures/qwen-stub.py                              (new)
+tests/voiceover/qwen.test.ts                             (new)
+tests/voiceover/*                                        (update to batch interface)
+README.md                                                (Qwen section)
+CHANGELOG.md                                             (entry)
+package.json                                             (version → 0.16.0)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-recast",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-recast",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-recast",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "module",
   "description": "Fluent pipeline library for processing Playwright traces into polished demo videos — TTS voiceover, subtitles, speed control, and zoom.",
   "license": "MIT",
@@ -50,6 +50,10 @@
       "types": "./dist/voiceover/providers/polly.d.ts",
       "default": "./dist/voiceover/providers/polly.js"
     },
+    "./providers/qwen": {
+      "types": "./dist/voiceover/providers/qwen.d.ts",
+      "default": "./dist/voiceover/providers/qwen.js"
+    },
     "./studio": {
       "types": "./dist/studio/types.d.ts",
       "default": "./dist/studio/recorder.js"
@@ -69,7 +73,7 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && cp -R src/voiceover/providers/qwen-sidecar dist/voiceover/providers/"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,10 +20,11 @@ OPTIONS
       --no-speed       Disable speed processing
       --text-processing Enable built-in text sanitization for TTS
       --text-processing-config <path>  JSON config with text processing rules
-      --provider       TTS provider: openai | elevenlabs | polly | none (default: none)
-      --voice          Voice ID for TTS provider
-      --model          Model ID for TTS provider
-      --tts-speed      TTS speech speed multiplier
+      --provider       TTS provider: openai | elevenlabs | polly | qwen | none (default: none)
+      --voice          Voice ID for TTS provider (openai/elevenlabs/polly)
+      --model          Model ID for TTS provider (openai/elevenlabs)
+      --tts-speed      TTS speech speed multiplier (openai)
+      --qwen-config <path>  JSON config file for the Qwen provider (required when --provider qwen)
       --format         Output format: mp4 | webm (default: mp4)
       --resolution     Output resolution: 720p | 1080p (default: 1080p)
       --burn-subs      Burn subtitles into video
@@ -43,6 +44,7 @@ EXAMPLES
   playwright-recast -i ./test-results -o demo.mp4
   playwright-recast -i trace.zip --speed-idle 4 --burn-subs
   playwright-recast -i ./traces --srt narration.srt --provider openai --voice nova
+  playwright-recast -i ./traces --srt narration.srt --provider qwen --qwen-config qwen.json
 `.trim()
 
 function fatal(message: string): never {
@@ -64,6 +66,7 @@ async function main(): Promise<void> {
       voice: { type: 'string' },
       model: { type: 'string' },
       'tts-speed': { type: 'string' },
+      'qwen-config': { type: 'string' },
       format: { type: 'string' },
       resolution: { type: 'string' },
       'text-processing': { type: 'boolean', default: false },
@@ -219,8 +222,16 @@ async function main(): Promise<void> {
           voice: values.voice,
         }),
       )
+    } else if (providerName === 'qwen') {
+      const configPath = values['qwen-config']
+      if (!configPath) {
+        fatal('--qwen-config <path> is required when --provider qwen. The JSON must include `mode`, `refText`, and `voiceSample` (clone) or `voiceDescription` (design).')
+      }
+      const qwenConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+      const { QwenTtsProvider } = await import('./voiceover/providers/qwen.js')
+      pipeline = pipeline.voiceover(QwenTtsProvider(qwenConfig))
     } else {
-      fatal(`Unknown provider: ${providerName}. Use openai, elevenlabs, polly, or none.`)
+      fatal(`Unknown provider: ${providerName}. Use openai, elevenlabs, polly, qwen, or none.`)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,12 @@ export { PollyProvider } from './voiceover/providers/polly.js'
 export type { OpenAIProviderConfig } from './voiceover/providers/openai.js'
 export type { ElevenLabsProviderConfig, ElevenLabsVoiceSettings } from './voiceover/providers/elevenlabs.js'
 export type { PollyProviderConfig } from './voiceover/providers/polly.js'
+export { QwenTtsProvider, QwenSidecarError } from './voiceover/providers/qwen.js'
+export type {
+  QwenTtsProviderConfig,
+  QwenCloneModeConfig,
+  QwenDesignModeConfig,
+} from './voiceover/providers/qwen.js'
 
 // Voiceover post-processing
 export { normalizeLoudness } from './voiceover/normalize.js'

--- a/src/types/voiceover.ts
+++ b/src/types/voiceover.ts
@@ -2,7 +2,7 @@ import type { SubtitleEntry, SubtitledTrace } from './subtitle.js'
 
 /** A chunk of synthesized audio */
 export interface AudioSegment {
-  data: Buffer
+  path: string
   durationMs: number
   format: {
     sampleRate: number
@@ -26,12 +26,19 @@ export interface TtsOptions {
   speed?: number
   /** Output audio format hint */
   format?: 'mp3' | 'wav' | 'opus' | 'pcm'
+  /** Directory the provider should write output files into. Caller owns cleanup. */
+  workDir?: string
 }
 
 /** The contract every TTS provider must implement */
 export interface TtsProvider {
   readonly name: string
-  synthesize(text: string, options?: TtsOptions): Promise<AudioSegment>
+  /**
+   * Synthesize speech for each text in `texts`. Returns one AudioSegment per
+   * input text, in order. Each segment's `path` points to a file on disk
+   * written by the provider (typically under `options.workDir`).
+   */
+  synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]>
   estimateDurationMs(text: string, options?: TtsOptions): number
   isAvailable(): Promise<boolean>
   dispose(): Promise<void>

--- a/src/voiceover/providers/elevenlabs.ts
+++ b/src/voiceover/providers/elevenlabs.ts
@@ -1,4 +1,6 @@
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
+import { resolveWorkDir } from './util/resolveWorkDir.js'
+import { writeAudioSegment } from './util/writeAudioSegment.js'
 
 export interface ElevenLabsVoiceSettings {
   stability?: number
@@ -57,36 +59,33 @@ export function ElevenLabsProvider(config: ElevenLabsProviderConfig = {}): TtsPr
   return {
     name: 'elevenlabs',
 
-    async synthesize(text: string, options?: TtsOptions): Promise<AudioSegment> {
+    async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
       const el = await getClient()
-      const voice = options?.voice ?? defaults.voice
-      const model = options?.model ?? defaults.model
-      const languageCode = options?.languageCode ?? defaults.languageCode
+      const dir = resolveWorkDir(options?.workDir)
+      return Promise.all(texts.map(async (text) => {
+        const voice = options?.voice ?? defaults.voice
+        const model = options?.model ?? defaults.model
+        const languageCode = options?.languageCode ?? defaults.languageCode
 
-      const params: Record<string, unknown> = {
-        text,
-        modelId: model,
-        outputFormat: 'mp3_44100_128',
-      }
-      if (languageCode) params.languageCode = languageCode
-      if (defaults.voiceSettings) params.voiceSettings = defaults.voiceSettings
+        const params: Record<string, unknown> = {
+          text,
+          modelId: model,
+          outputFormat: 'mp3_44100_128',
+        }
+        if (languageCode) params.languageCode = languageCode
+        if (defaults.voiceSettings) params.voiceSettings = defaults.voiceSettings
 
-      const audio = await el.textToSpeech.convert(voice, params)
-
-      const reader = audio.getReader()
-      const chunks: Uint8Array[] = []
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        chunks.push(value)
-      }
-
-      const data = Buffer.concat(chunks)
-      return {
-        data,
-        durationMs: 0,
-        format: { sampleRate: 44100, channels: 1, codec: 'mp3' },
-      }
+        const audio = await el.textToSpeech.convert(voice, params)
+        const reader = audio.getReader()
+        const chunks: Uint8Array[] = []
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          chunks.push(value)
+        }
+        const buf = Buffer.concat(chunks)
+        return writeAudioSegment(buf, { dir, prefix: 'elevenlabs', sampleRate: 44100 })
+      }))
     },
 
     estimateDurationMs(text: string): number {

--- a/src/voiceover/providers/openai.ts
+++ b/src/voiceover/providers/openai.ts
@@ -1,4 +1,6 @@
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
+import { resolveWorkDir } from './util/resolveWorkDir.js'
+import { writeAudioSegment } from './util/writeAudioSegment.js'
 
 export interface OpenAIProviderConfig {
   apiKey?: string
@@ -51,25 +53,22 @@ export function OpenAIProvider(config: OpenAIProviderConfig = {}): TtsProvider {
   return {
     name: 'openai',
 
-    async synthesize(text: string, options?: TtsOptions): Promise<AudioSegment> {
+    async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
       const openai = await getClient()
-      const params: Record<string, unknown> = {
-        model: options?.model ?? defaults.model,
-        voice: options?.voice ?? defaults.voice,
-        speed: options?.speed ?? defaults.speed,
-        input: text,
-        response_format: 'mp3',
-      }
-      if (defaults.instructions) params.instructions = defaults.instructions
-
-      const response = await openai.audio.speech.create(params)
-      const data = Buffer.from(await response.arrayBuffer())
-
-      return {
-        data,
-        durationMs: 0,
-        format: { sampleRate: 24000, channels: 1, codec: 'mp3' },
-      }
+      const dir = resolveWorkDir(options?.workDir)
+      return Promise.all(texts.map(async (text) => {
+        const params: Record<string, unknown> = {
+          model: options?.model ?? defaults.model,
+          voice: options?.voice ?? defaults.voice,
+          speed: options?.speed ?? defaults.speed,
+          input: text,
+          response_format: 'mp3',
+        }
+        if (defaults.instructions) params.instructions = defaults.instructions
+        const response = await openai.audio.speech.create(params)
+        const buf = Buffer.from(await response.arrayBuffer())
+        return writeAudioSegment(buf, { dir, prefix: 'openai', sampleRate: 24000 })
+      }))
     },
 
     estimateDurationMs(text: string, options?: TtsOptions): number {

--- a/src/voiceover/providers/polly.ts
+++ b/src/voiceover/providers/polly.ts
@@ -1,4 +1,6 @@
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
+import { resolveWorkDir } from './util/resolveWorkDir.js'
+import { writeAudioSegment } from './util/writeAudioSegment.js'
 
 export interface PollyProviderConfig {
   region?: string
@@ -75,34 +77,36 @@ export function PollyProvider(config: PollyProviderConfig = {}): TtsProvider {
   return {
     name: 'polly',
 
-    async synthesize(text: string, options?: TtsOptions): Promise<AudioSegment> {
+    async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
       const polly = await getClient()
       const Cmd = SynthesizeSpeechCommand!
-      const voice = options?.voice ?? defaults.voice
-      const languageCode = options?.languageCode ?? defaults.languageCode
+      const dir = resolveWorkDir(options?.workDir)
 
-      const input: Record<string, unknown> = {
-        Text: text,
-        OutputFormat: 'mp3',
-        VoiceId: voice,
-        Engine: defaults.engine,
-        SampleRate: defaults.sampleRate,
-        TextType: defaults.textType,
-      }
-      if (languageCode) input.LanguageCode = languageCode
+      return Promise.all(texts.map(async (text) => {
+        const voice = options?.voice ?? defaults.voice
+        const languageCode = options?.languageCode ?? defaults.languageCode
+        const input: Record<string, unknown> = {
+          Text: text,
+          OutputFormat: 'mp3',
+          VoiceId: voice,
+          Engine: defaults.engine,
+          SampleRate: defaults.sampleRate,
+          TextType: defaults.textType,
+        }
+        if (languageCode) input.LanguageCode = languageCode
 
-      const command = new Cmd(input)
-      const response = await polly.send(command)
-      if (!response.AudioStream) {
-        throw new Error('Amazon Polly returned no audio stream')
-      }
-      const data = Buffer.from(await response.AudioStream.transformToByteArray())
-
-      return {
-        data,
-        durationMs: 0,
-        format: { sampleRate: Number(defaults.sampleRate), channels: 1, codec: 'mp3' },
-      }
+        const command = new Cmd(input)
+        const response = await polly.send(command)
+        if (!response.AudioStream) {
+          throw new Error('Amazon Polly returned no audio stream')
+        }
+        const buf = Buffer.from(await response.AudioStream.transformToByteArray())
+        return writeAudioSegment(buf, {
+          dir,
+          prefix: 'polly',
+          sampleRate: Number(defaults.sampleRate),
+        })
+      }))
     },
 
     estimateDurationMs(text: string, options?: TtsOptions): number {

--- a/src/voiceover/providers/qwen-sidecar/.npmignore
+++ b/src/voiceover/providers/qwen-sidecar/.npmignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+*.pyo

--- a/src/voiceover/providers/qwen-sidecar/README.md
+++ b/src/voiceover/providers/qwen-sidecar/README.md
@@ -1,0 +1,53 @@
+# Qwen3-TTS sidecar
+
+Python sidecar invoked by `QwenTtsProvider`. Reads a single JSON request from
+stdin, generates voice-design and/or voice-clone audio, writes WAV files into
+the request's `workDir`, and prints a single JSON response on stdout.
+
+## Requirements
+
+- Python 3.10+
+- CUDA-capable GPU (≥ 8 GB VRAM for the 1.7B design model; ≥ 4 GB for the
+  0.6B clone model)
+- An `HF_TOKEN` in the environment if downloading gated Qwen weights
+
+## Install
+
+The deps (PyTorch + flash-attn + Qwen) are ~5–8 GB. Recommended pattern is
+**one shared venv reused across projects**:
+
+```bash
+python3 -m venv ~/.venvs/qwen-tts
+~/.venvs/qwen-tts/bin/pip install -r requirements.txt
+```
+
+When invoked from `QwenTtsProvider`, point `pythonBin` at it — absolute
+path, no shell activation needed:
+
+```typescript
+QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './ref.wav',
+  refText: 'Sample transcript.',
+  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+})
+```
+
+Alternatives:
+
+- **`uv`** — `uv venv ~/.venvs/qwen-tts && uv pip install -p ~/.venvs/qwen-tts/bin/python -r requirements.txt`. Hardlinks from a global store, so even per-project venvs are nearly free on disk.
+- **Per-project `.venv`** — `python3 -m venv .venv` for full isolation; costs ~5–8 GB/project without `uv`.
+- **Conda** — same idea; pass the env's `bin/python3` to `pythonBin`.
+
+`flash-attn` requires CUDA toolchain at build time. If the precompiled wheel
+is unavailable for your environment, follow the install instructions at
+<https://github.com/Dao-AILab/flash-attention>.
+
+## Manually invoke (debugging)
+
+```bash
+echo '{"workDir":"/tmp/qwen","device":"cuda:0","dtype":"bfloat16","language":"English","cloneModel":"Qwen/Qwen3-TTS-12Hz-0.6B-Base","clone":{"refAudio":"/path/ref.wav","refText":"Welcome","texts":["hello"]}}' \
+  | python3 sidecar.py
+```
+
+The provider in `qwen.ts` is the canonical caller.

--- a/src/voiceover/providers/qwen-sidecar/requirements.txt
+++ b/src/voiceover/providers/qwen-sidecar/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.4.0
+numpy>=1.26.0
+psutil>=5.9.0
+soundfile>=0.12.1
+qwen-tts>=0.1.0
+flash-attn>=2.5.0

--- a/src/voiceover/providers/qwen-sidecar/sidecar.py
+++ b/src/voiceover/providers/qwen-sidecar/sidecar.py
@@ -1,0 +1,78 @@
+"""Qwen3-TTS sidecar.
+
+Reads one JSON request from stdin, generates audio, writes one JSON
+response to stdout. See README.md and ../qwen.ts for the protocol.
+"""
+import json
+import sys
+import traceback
+
+stage = "init"
+results = {"ok": True}
+
+try:
+    # Imports inside the try block so missing Python deps (ImportError) and
+    # bad request JSON both surface via the structured 'init' error channel.
+    import soundfile as sf
+    import torch
+    from qwen_tts import Qwen3TTSModel
+
+    req = json.loads(sys.stdin.read())
+    work_dir = req["workDir"]
+    device = req["device"]
+    dtype_name = req["dtype"]
+    language = req["language"]
+    torch_dtype = getattr(torch, dtype_name)
+
+    if "design" in req:
+        stage = "design"
+        d = req["design"]
+        model = Qwen3TTSModel.from_pretrained(
+            d["designModel"],
+            device_map=device,
+            dtype=torch_dtype,
+            attn_implementation="flash_attention_2",
+        )
+        wavs, sr = model.generate_voice_design(
+            text=[d["refText"]],
+            language=language,
+            do_sample=False, top_p=1.0, num_beams=1,
+            instruct=[d["voiceDescription"]],
+        )
+        design_path = f"{work_dir}/design.wav"
+        sf.write(design_path, wavs[0], sr)
+        results["design"] = {"path": design_path}
+        del model
+        torch.cuda.empty_cache()
+
+    if req.get("clone", {}).get("texts"):
+        stage = "clone"
+        c = req["clone"]
+        model = Qwen3TTSModel.from_pretrained(
+            req["cloneModel"],
+            device_map=device,
+            dtype=torch_dtype,
+            attn_implementation="flash_attention_2",
+        )
+        wavs, sr = model.generate_voice_clone(
+            text=c["texts"],
+            language=language,
+            ref_audio=c["refAudio"],
+            ref_text=c["refText"],
+        )
+        clone_results = []
+        for i, wav in enumerate(wavs):
+            p = f"{work_dir}/clone-{i}.wav"
+            sf.write(p, wav, sr)
+            clone_results.append({"path": p})
+        results["clone"] = clone_results
+
+    print(json.dumps(results))
+except Exception as e:  # noqa: BLE001 — top-level catch is the design
+    print(json.dumps({
+        "ok": False,
+        "stage": stage,
+        "error": str(e),
+        "traceback": traceback.format_exc(),
+    }))
+    sys.exit(1)

--- a/src/voiceover/providers/qwen.ts
+++ b/src/voiceover/providers/qwen.ts
@@ -1,0 +1,387 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
+import { hashValues, hashFile } from './util/hash.js'
+
+interface QwenTtsCommonConfig {
+  refText: string
+  language?: string
+  cloneModel?: string
+  cacheDir?: string
+  cacheAudio?: boolean
+  pythonBin?: string
+  device?: string
+  dtype?: 'bfloat16' | 'float16' | 'float32'
+  /** @internal — test-only override of the sidecar script path. */
+  __pythonScriptPath__?: string
+}
+
+export interface QwenCloneModeConfig extends QwenTtsCommonConfig {
+  mode: 'clone'
+  voiceSample: string
+}
+
+export interface QwenDesignModeConfig extends QwenTtsCommonConfig {
+  mode: 'design'
+  voiceDescription: string
+  designModel?: string
+  cacheVoiceDesign?: boolean
+}
+
+export type QwenTtsProviderConfig = QwenCloneModeConfig | QwenDesignModeConfig
+
+const DEFAULT_CLONE_MODEL = 'Qwen/Qwen3-TTS-12Hz-0.6B-Base'
+const DEFAULT_DESIGN_MODEL = 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign'
+const DEFAULT_CACHE_DIR = './.recast-cache/voice'
+const DEFAULT_LANGUAGE = 'English'
+const DEFAULT_PYTHON_BIN = 'python3'
+const DEFAULT_DEVICE = 'cuda:0'
+const DEFAULT_DTYPE = 'bfloat16' as const
+
+export class QwenSidecarError extends Error {
+  readonly stage: 'init' | 'design' | 'clone'
+  readonly pythonTraceback?: string
+  constructor(stage: 'init' | 'design' | 'clone', message: string, traceback?: string) {
+    super(`Qwen sidecar failed at stage '${stage}': ${message}`)
+    this.name = 'QwenSidecarError'
+    this.stage = stage
+    this.pythonTraceback = traceback
+  }
+}
+
+interface SidecarRequest {
+  workDir: string
+  device: string
+  dtype: 'bfloat16' | 'float16' | 'float32'
+  language: string
+  cloneModel: string
+  design?: {
+    designModel: string
+    voiceDescription: string
+    refText: string
+  }
+  clone?: {
+    refAudio: string
+    refText: string
+    texts: string[]
+  }
+}
+
+interface SidecarResponseOk {
+  ok: true
+  design?: { path: string }
+  clone?: Array<{ path: string }>
+}
+
+interface SidecarResponseErr {
+  ok: false
+  stage: 'init' | 'design' | 'clone'
+  error: string
+  traceback?: string
+}
+
+type SidecarResponse = SidecarResponseOk | SidecarResponseErr
+
+interface SynthesisPlan {
+  targets: Array<{ text: string; cachePath: string; hash: string }>
+  /** Output path per input index. Cache hits + filled-in misses + duplicates. */
+  paths: string[]
+  /** Input indices that need to be synthesized by the sidecar. */
+  missIndices: number[]
+  /** Duplicates resolved by copying the canonical miss's output. */
+  duplicates: Array<{ index: number; canonicalIndex: number }>
+}
+
+function runSidecar(
+  pythonBin: string,
+  scriptOverride: string | undefined,
+  req: SidecarRequest,
+): SidecarResponseOk {
+  const scriptPath = scriptOverride
+    ?? path.join(path.dirname(fileURLToPath(import.meta.url)), 'qwen-sidecar', 'sidecar.py')
+  const r = spawnSync(pythonBin, [scriptPath], {
+    input: JSON.stringify(req),
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  if (r.error && (r.error as NodeJS.ErrnoException).code === 'ENOENT') {
+    throw new Error(
+      `QwenTtsProvider: could not spawn '${pythonBin}'. ` +
+        `Install Python 3 or set pythonBin in config.`,
+    )
+  }
+  const stdout = (r.stdout ?? '').trim()
+  let parsed: SidecarResponse | undefined
+  if (stdout) {
+    try {
+      parsed = JSON.parse(stdout) as SidecarResponse
+    } catch {
+      // fall through — handled by exit code branch
+    }
+  }
+  if (r.status === 0 && parsed && parsed.ok) {
+    return parsed
+  }
+  if (parsed && !parsed.ok) {
+    throw new QwenSidecarError(parsed.stage, parsed.error, parsed.traceback)
+  }
+  const stderr = (r.stderr ?? '').trim()
+  throw new Error(
+    `Qwen sidecar exited with status ${r.status}.\nstdout: ${stdout}\nstderr: ${stderr}`,
+  )
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+function convertWavToMp3(wavPath: string, mp3Path: string): void {
+  ensureDir(path.dirname(mp3Path))
+  execFileSync('ffmpeg', [
+    '-y', '-hide_banner', '-loglevel', 'error',
+    '-i', wavPath,
+    '-ac', '1',
+    '-c:a', 'libmp3lame', '-b:a', '192k',
+    mp3Path,
+  ], { stdio: 'pipe' })
+}
+
+export function QwenTtsProvider(config: QwenTtsProviderConfig): TtsProvider {
+  if (!config.refText) {
+    throw new Error('QwenTtsProvider: refText is required (in both clone and design modes)')
+  }
+  if (config.mode === 'clone') {
+    if (!config.voiceSample) {
+      throw new Error('QwenTtsProvider: voiceSample is required in clone mode')
+    }
+  } else if (config.mode === 'design') {
+    if (!config.voiceDescription) {
+      throw new Error('QwenTtsProvider: voiceDescription is required in design mode')
+    }
+  } else {
+    throw new Error("QwenTtsProvider: mode must be 'clone' or 'design'")
+  }
+
+  const language = config.language ?? DEFAULT_LANGUAGE
+  const cloneModel = config.cloneModel ?? DEFAULT_CLONE_MODEL
+  const cacheDir = config.cacheDir ?? DEFAULT_CACHE_DIR
+  const cacheAudio = config.cacheAudio ?? false
+  const pythonBin = config.pythonBin ?? DEFAULT_PYTHON_BIN
+  const device = config.device ?? DEFAULT_DEVICE
+  const dtype = config.dtype ?? DEFAULT_DTYPE
+
+  // Compute the reference-audio fingerprint once per provider instance.
+  // In clone mode it's the hash of the user-provided file.
+  // In design mode it equals designHashValue (the reference is derived from design inputs).
+  let designModel: string | undefined
+  let voiceDescription: string | undefined
+  let cacheVoiceDesign = false
+  let refAudioFingerprint: string
+  let designHashValue: string | undefined
+
+  if (config.mode === 'clone') {
+    refAudioFingerprint = hashFile(config.voiceSample)
+  } else {
+    designModel = config.designModel ?? DEFAULT_DESIGN_MODEL
+    voiceDescription = config.voiceDescription
+    cacheVoiceDesign = config.cacheVoiceDesign ?? false
+    designHashValue = hashValues([
+      'design',
+      voiceDescription,
+      config.refText,
+      language,
+      designModel,
+      dtype,
+    ])
+    refAudioFingerprint = designHashValue
+  }
+
+  function audioCachePathFor(text: string): { hash: string; cachePath: string } {
+    const hash = hashValues([
+      'audio',
+      text,
+      language,
+      cloneModel,
+      dtype,
+      config.refText,
+      refAudioFingerprint,
+    ])
+    return { hash, cachePath: path.join(cacheDir, 'audio', `${hash}.mp3`) }
+  }
+
+  function designCachePath(): string {
+    return path.join(cacheDir, 'design', `${designHashValue}.wav`)
+  }
+
+  /** Partition `texts` into cache hits (resolved immediately), misses (to send to
+   *  the sidecar), and duplicates (filled later by copying a canonical miss). */
+  function planSynthesis(texts: string[], tmpDir: string): SynthesisPlan {
+    const targets = texts.map((text) => {
+      const { hash, cachePath } = audioCachePathFor(text)
+      return { text, cachePath, hash }
+    })
+    const paths: string[] = Array.from({ length: targets.length }, () => '')
+    const missIndices: number[] = []
+    const duplicates: Array<{ index: number; canonicalIndex: number }> = []
+    const canonicalByHash = new Map<string, number>()
+    for (let i = 0; i < targets.length; i++) {
+      const t = targets[i]!
+      if (cacheAudio && fs.existsSync(t.cachePath)) {
+        const ephemeral = path.join(tmpDir, `qwen-cachehit-${t.hash}.mp3`)
+        fs.copyFileSync(t.cachePath, ephemeral)
+        paths[i] = ephemeral
+        continue
+      }
+      const canonicalIndex = canonicalByHash.get(t.hash)
+      if (canonicalIndex !== undefined) {
+        duplicates.push({ index: i, canonicalIndex })
+      } else {
+        missIndices.push(i)
+        canonicalByHash.set(t.hash, i)
+      }
+    }
+    return { targets, paths, missIndices, duplicates }
+  }
+
+  /** Pick the reference audio path and decide whether the sidecar must generate
+   *  a fresh design WAV first. */
+  function resolveRefAudio(sidecarDir: string): { refAudio: string; scheduledDesign: boolean } {
+    if (config.mode === 'clone') {
+      return { refAudio: config.voiceSample, scheduledDesign: false }
+    }
+    const cached = designCachePath()
+    if (cacheVoiceDesign && fs.existsSync(cached)) {
+      return { refAudio: cached, scheduledDesign: false }
+    }
+    return { refAudio: path.join(sidecarDir, 'design.wav'), scheduledDesign: true }
+  }
+
+  function buildSidecarRequest(
+    plan: SynthesisPlan,
+    sidecarDir: string,
+    refAudio: string,
+    scheduledDesign: boolean,
+  ): SidecarRequest {
+    const req: SidecarRequest = {
+      workDir: sidecarDir,
+      device, dtype, language, cloneModel,
+    }
+    if (scheduledDesign) {
+      req.design = {
+        designModel: designModel!,
+        voiceDescription: voiceDescription!,
+        refText: config.refText,
+      }
+    }
+    if (plan.missIndices.length > 0) {
+      req.clone = {
+        refAudio,
+        refText: config.refText,
+        texts: plan.missIndices.map((i) => plan.targets[i]!.text),
+      }
+    }
+    return req
+  }
+
+  /** Move the freshly produced design WAV into the cache if caching is enabled.
+   *  Otherwise leaves it under sidecarDir, where the caller cleans it up. */
+  function persistDesignWav(producedPath: string): void {
+    if (!cacheVoiceDesign || !designHashValue) return
+    const target = designCachePath()
+    ensureDir(path.dirname(target))
+    try {
+      fs.renameSync(producedPath, target)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err
+      fs.copyFileSync(producedPath, target)
+      fs.unlinkSync(producedPath)
+    }
+  }
+
+  /** Convert each clone WAV to MP3 and record its ephemeral path in the plan.
+   *  When caching, writes to the cache first and hands the processor a copy so
+   *  a renameSync in the caller cannot destroy the cached file. */
+  function persistCloneWavs(
+    cloneWavs: ReadonlyArray<{ path: string }>,
+    plan: SynthesisPlan,
+    tmpDir: string,
+  ): void {
+    for (let k = 0; k < cloneWavs.length; k++) {
+      const targetIdx = plan.missIndices[k]!
+      const t = plan.targets[targetIdx]!
+      const ephemeral = path.join(tmpDir, `qwen-${t.hash}.mp3`)
+      if (cacheAudio) {
+        convertWavToMp3(cloneWavs[k]!.path, t.cachePath)
+        fs.copyFileSync(t.cachePath, ephemeral)
+      } else {
+        convertWavToMp3(cloneWavs[k]!.path, ephemeral)
+      }
+      plan.paths[targetIdx] = ephemeral
+    }
+  }
+
+  /** Each duplicate gets its own ephemeral copy so the processor can rename or
+   *  move each path independently without hitting ENOENT on reuse. */
+  function fillDuplicates(plan: SynthesisPlan, tmpDir: string): void {
+    for (const { index, canonicalIndex } of plan.duplicates) {
+      const { hash } = plan.targets[index]!
+      const dupPath = path.join(tmpDir, `qwen-dup-${index}-${hash}.mp3`)
+      fs.copyFileSync(plan.paths[canonicalIndex]!, dupPath)
+      plan.paths[index] = dupPath
+    }
+  }
+
+  function buildResult(plan: SynthesisPlan): AudioSegment[] {
+    return plan.paths.map((p) => ({
+      path: p,
+      durationMs: 0,
+      format: { sampleRate: 24000, channels: 1, codec: 'mp3' },
+    }))
+  }
+
+  return {
+    name: 'qwen',
+
+    async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
+      const tmpDir = options?.workDir ?? os.tmpdir()
+      ensureDir(tmpDir)
+      // Sidecar runs need their own workspace so cleanup is unambiguous.
+      const sidecarDir = path.join(tmpDir, `qwen-${crypto.randomUUID()}`)
+      ensureDir(sidecarDir)
+      try {
+        const plan = planSynthesis(texts, tmpDir)
+        const { refAudio, scheduledDesign } = resolveRefAudio(sidecarDir)
+        if (scheduledDesign || plan.missIndices.length > 0) {
+          const resp = runSidecar(
+            pythonBin,
+            config.__pythonScriptPath__,
+            buildSidecarRequest(plan, sidecarDir, refAudio, scheduledDesign),
+          )
+          if (resp.design) persistDesignWav(resp.design.path)
+          persistCloneWavs(resp.clone ?? [], plan, tmpDir)
+        }
+        fillDuplicates(plan, tmpDir)
+        return buildResult(plan)
+      } finally {
+        fs.rmSync(sidecarDir, { recursive: true, force: true })
+      }
+    },
+
+    estimateDurationMs(text: string): number {
+      const words = text.split(/\s+/).length
+      return (words / 150) * 60_000
+    },
+
+    async isAvailable(): Promise<boolean> {
+      return true
+    },
+
+    async dispose(): Promise<void> {
+      // sidecar is per-call; nothing to release
+    },
+  }
+}

--- a/src/voiceover/providers/util/hash.ts
+++ b/src/voiceover/providers/util/hash.ts
@@ -1,0 +1,12 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+
+/** SHA-256 over the values, joined with NUL so `['a', 'bc']` ≠ `['ab', 'c']`. */
+export function hashValues(values: ReadonlyArray<string | number | boolean>): string {
+  return crypto.createHash('sha256').update(values.join('\0')).digest('hex')
+}
+
+/** SHA-256 of the file's contents. */
+export function hashFile(filePath: string): string {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}

--- a/src/voiceover/providers/util/resolveWorkDir.ts
+++ b/src/voiceover/providers/util/resolveWorkDir.ts
@@ -1,0 +1,9 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+
+/** Resolve options.workDir → existing directory. Call once per synthesize(). */
+export function resolveWorkDir(workDir: string | undefined): string {
+  const dir = workDir ?? os.tmpdir()
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}

--- a/src/voiceover/providers/util/writeAudioSegment.ts
+++ b/src/voiceover/providers/util/writeAudioSegment.ts
@@ -1,0 +1,33 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as crypto from 'node:crypto'
+import type { AudioSegment } from '../../../types/voiceover.js'
+
+export interface WriteAudioSegmentOptions {
+  dir: string
+  prefix: string
+  sampleRate: number
+  /** Codec recorded in the returned AudioSegment.format. Default: 'mp3'. */
+  codec?: string
+  /** File extension. Default: same as codec. */
+  ext?: string
+  /** Channel count recorded in the returned AudioSegment.format. Default: 1. */
+  channels?: number
+}
+
+/** Write `buf` to `<dir>/<prefix>-<uuid>.<ext>` and build the AudioSegment. */
+export async function writeAudioSegment(
+  buf: Buffer,
+  opts: WriteAudioSegmentOptions,
+): Promise<AudioSegment> {
+  const codec = opts.codec ?? 'mp3'
+  const ext = opts.ext ?? codec
+  const channels = opts.channels ?? 1
+  const filePath = path.join(opts.dir, `${opts.prefix}-${crypto.randomUUID()}.${ext}`)
+  await fs.promises.writeFile(filePath, buf)
+  return {
+    path: filePath,
+    durationMs: 0,
+    format: { sampleRate: opts.sampleRate, channels, codec },
+  }
+}

--- a/src/voiceover/voiceover-processor.ts
+++ b/src/voiceover/voiceover-processor.ts
@@ -56,6 +56,15 @@ export async function generateVoiceover(
   fs.mkdirSync(tmpDir, { recursive: true })
   const normalizeConfig = resolveNormalize(options?.normalize)
 
+  const texts = trace.subtitles.map((s) => s.ttsText ?? s.text)
+  const audios = await provider.synthesize(texts, { workDir: tmpDir })
+
+  if (audios.length !== texts.length) {
+    throw new Error(
+      `Provider "${provider.name}" returned ${audios.length} segments for ${texts.length} texts`,
+    )
+  }
+
   const entries: VoiceoverEntry[] = []
   const segmentFiles: string[] = []
   const freezes: VoiceoverFreeze[] = []
@@ -68,6 +77,7 @@ export async function generateVoiceover(
 
   for (let si = 0; si < trace.subtitles.length; si++) {
     const subtitle = trace.subtitles[si]!
+    const audio = audios[si]!
 
     subtitle.startMs += timeShift
     subtitle.endMs += timeShift
@@ -80,17 +90,19 @@ export async function generateVoiceover(
       segmentFiles.push(silencePath)
     }
 
-    // Synthesize raw TTS into a staging file, then (optionally) normalize into
-    // the canonical seg-N.mp3 path that gets concatenated.
     const segPath = path.join(tmpDir, `seg-${subtitle.index}.mp3`)
-    const audio = await provider.synthesize(subtitle.ttsText ?? subtitle.text)
-
     if (normalizeConfig) {
-      const rawPath = path.join(tmpDir, `raw-${subtitle.index}.mp3`)
-      fs.writeFileSync(rawPath, audio.data)
-      await normalizeLoudness(rawPath, segPath, normalizeConfig)
+      await normalizeLoudness(audio.path, segPath, normalizeConfig)
     } else {
-      fs.writeFileSync(segPath, audio.data)
+      // Move (rename) the provider's output into the canonical seg-N.mp3 slot.
+      // Falls back to copy+unlink across devices.
+      try {
+        fs.renameSync(audio.path, segPath)
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err
+        fs.copyFileSync(audio.path, segPath)
+        fs.unlinkSync(audio.path)
+      }
     }
 
     const audioDuration = getAudioDurationMs(segPath)

--- a/tests/fixtures/qwen-stub.py
+++ b/tests/fixtures/qwen-stub.py
@@ -1,0 +1,65 @@
+"""Stub sidecar used by qwen.test.ts.
+
+Mimics the real protocol: reads request JSON from stdin, writes short
+silence WAVs to the requested workDir, prints a response on stdout.
+Has no torch/qwen-tts dependency.
+
+Supports env vars for failure injection:
+  QWEN_STUB_FAIL_STAGE = init|design|clone  -> emit error response at that stage
+"""
+import json
+import os
+import struct
+import sys
+import traceback
+import wave
+
+
+def write_silence_wav(path: str, duration_sec: float = 0.5, sample_rate: int = 24000) -> None:
+    n_samples = int(duration_sec * sample_rate)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)  # 16-bit
+        w.setframerate(sample_rate)
+        w.writeframes(struct.pack("<" + "h" * n_samples, *([0] * n_samples)))
+
+
+fail_stage = os.environ.get("QWEN_STUB_FAIL_STAGE")
+stage = "init"
+results = {"ok": True}
+
+try:
+    if fail_stage == "init":
+        raise RuntimeError("stub init failure")
+
+    req = json.loads(sys.stdin.read())
+    work_dir = req["workDir"]
+
+    if "design" in req:
+        stage = "design"
+        if fail_stage == "design":
+            raise RuntimeError("stub design failure")
+        path = f"{work_dir}/design.wav"
+        write_silence_wav(path)
+        results["design"] = {"path": path}
+
+    if req.get("clone", {}).get("texts"):
+        stage = "clone"
+        if fail_stage == "clone":
+            raise RuntimeError("stub clone failure")
+        clone_results = []
+        for i, _text in enumerate(req["clone"]["texts"]):
+            p = f"{work_dir}/clone-{i}.wav"
+            write_silence_wav(p)
+            clone_results.append({"path": p})
+        results["clone"] = clone_results
+
+    print(json.dumps(results))
+except Exception as e:
+    print(json.dumps({
+        "ok": False,
+        "stage": stage,
+        "error": str(e),
+        "traceback": traceback.format_exc(),
+    }))
+    sys.exit(1)

--- a/tests/unit/pipeline/pipeline.test.ts
+++ b/tests/unit/pipeline/pipeline.test.ts
@@ -93,7 +93,7 @@ describe('Pipeline (fluent chain)', () => {
   it('preserves voiceover provider', () => {
     const mockProvider = {
       name: 'mock',
-      synthesize: async () => ({ data: Buffer.from(''), durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } }),
+      synthesize: async (texts: string[]) => texts.map(() => ({ path: '', durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } })),
       estimateDurationMs: () => 1000,
       isAvailable: async () => true,
       dispose: async () => {},

--- a/tests/unit/pipeline/voiceover-stage.test.ts
+++ b/tests/unit/pipeline/voiceover-stage.test.ts
@@ -4,7 +4,7 @@ import type { TtsProvider } from '../../../src/types/voiceover'
 
 const fakeProvider: TtsProvider = {
   name: 'fake',
-  async synthesize() { return { data: Buffer.alloc(0), durationMs: 0, format: { sampleRate: 44100, channels: 1, codec: 'mp3' } } },
+  async synthesize() { return [] },
   estimateDurationMs() { return 0 },
   async isAvailable() { return true },
   async dispose() {},

--- a/tests/unit/voiceover/hash.test.ts
+++ b/tests/unit/voiceover/hash.test.ts
@@ -1,0 +1,56 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { hashValues, hashFile } from '../../../src/voiceover/providers/util/hash.js'
+
+const TMP = path.join(os.tmpdir(), `hash-test-${process.pid}`)
+beforeAll(() => fs.mkdirSync(TMP, { recursive: true }))
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }))
+
+describe('hashValues', () => {
+  it('is deterministic', () => {
+    expect(hashValues(['a', 'b', 'c'])).toBe(hashValues(['a', 'b', 'c']))
+  })
+
+  it('returns a 64-char sha256 hex string', () => {
+    expect(hashValues(['a'])).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('changes when any value changes', () => {
+    const base = hashValues(['a', 'b', 'c'])
+    expect(hashValues(['x', 'b', 'c'])).not.toBe(base)
+    expect(hashValues(['a', 'x', 'c'])).not.toBe(base)
+    expect(hashValues(['a', 'b', 'x'])).not.toBe(base)
+  })
+
+  it('changes when order changes', () => {
+    expect(hashValues(['a', 'b'])).not.toBe(hashValues(['b', 'a']))
+  })
+
+  it('does not collide across boundary positions (NUL separator)', () => {
+    expect(hashValues(['a', 'bc'])).not.toBe(hashValues(['ab', 'c']))
+  })
+
+  it('accepts numbers and booleans', () => {
+    expect(hashValues([1, 2, true])).toMatch(/^[a-f0-9]{64}$/)
+    expect(hashValues([1, 2, true])).not.toBe(hashValues([1, 2, false]))
+  })
+})
+
+describe('hashFile', () => {
+  it('returns sha256 hex of the file contents', () => {
+    const filePath = path.join(TMP, 'sample.bin')
+    fs.writeFileSync(filePath, Buffer.from('hello world'))
+    // sha256("hello world")
+    expect(hashFile(filePath)).toBe('b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9')
+  })
+
+  it('changes when file contents change', () => {
+    const a = path.join(TMP, 'a.bin')
+    const b = path.join(TMP, 'b.bin')
+    fs.writeFileSync(a, 'foo')
+    fs.writeFileSync(b, 'bar')
+    expect(hashFile(a)).not.toBe(hashFile(b))
+  })
+})

--- a/tests/unit/voiceover/providers.test.ts
+++ b/tests/unit/voiceover/providers.test.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ElevenLabsProvider } from '../../../src/voiceover/providers/elevenlabs'
 import { OpenAIProvider } from '../../../src/voiceover/providers/openai'
 import { PollyProvider } from '../../../src/voiceover/providers/polly'
+
+const TMP_ROOT = path.join(os.tmpdir(), `recast-providers-test-${process.pid}`)
+beforeAll(() => { fs.mkdirSync(TMP_ROOT, { recursive: true }) })
+afterAll(() => { fs.rmSync(TMP_ROOT, { recursive: true, force: true }) })
 
 // vi.mock is hoisted — use vi.hoisted() so the mock functions exist when the
 // factory runs, and use `class` for constructable mocks (arrow functions are
@@ -55,19 +62,21 @@ describe('ElevenLabsProvider', () => {
     mocks.convertMock.mockResolvedValue(makeStream(new Uint8Array([1, 2, 3])))
   })
 
-  it('sends voice, model and languageCode from factory config', async () => {
-    const p = ElevenLabsProvider({
-      apiKey: 'k', voice: 'v1', model: 'm1', languageCode: 'cs',
-    })
-    await p.synthesize('hello')
-    expect(mocks.convertMock).toHaveBeenCalledWith('v1', expect.objectContaining({
+  it('sends voice, model and languageCode for each text in the batch', async () => {
+    const p = ElevenLabsProvider({ apiKey: 'k', voice: 'v1', model: 'm1', languageCode: 'cs' })
+    const results = await p.synthesize(['hello', 'world'], { workDir: TMP_ROOT })
+    expect(results).toHaveLength(2)
+    expect(results[0]!.path).toMatch(/elevenlabs-.*\.mp3$/)
+    expect(fs.existsSync(results[0]!.path)).toBe(true)
+    expect(mocks.convertMock).toHaveBeenCalledTimes(2)
+    expect(mocks.convertMock).toHaveBeenNthCalledWith(1, 'v1', expect.objectContaining({
       text: 'hello', modelId: 'm1', languageCode: 'cs', outputFormat: 'mp3_44100_128',
     }))
   })
 
   it('options override factory config per call', async () => {
     const p = ElevenLabsProvider({ apiKey: 'k', voice: 'v1', model: 'm1', languageCode: 'cs' })
-    await p.synthesize('hello', { voice: 'v2', model: 'm2', languageCode: 'en' })
+    await p.synthesize(['hello'], { workDir: TMP_ROOT, voice: 'v2', model: 'm2', languageCode: 'en' })
     expect(mocks.convertMock).toHaveBeenCalledWith('v2', expect.objectContaining({
       modelId: 'm2', languageCode: 'en',
     }))
@@ -78,7 +87,7 @@ describe('ElevenLabsProvider', () => {
       apiKey: 'k',
       voiceSettings: { stability: 0.75, similarityBoost: 0.8, style: 0.1, useSpeakerBoost: true },
     })
-    await p.synthesize('x')
+    await p.synthesize(['x'], { workDir: TMP_ROOT })
     expect(mocks.convertMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
       voiceSettings: { stability: 0.75, similarityBoost: 0.8, style: 0.1, useSpeakerBoost: true },
     }))
@@ -86,7 +95,7 @@ describe('ElevenLabsProvider', () => {
 
   it('omits voiceSettings when not provided', async () => {
     const p = ElevenLabsProvider({ apiKey: 'k' })
-    await p.synthesize('x')
+    await p.synthesize(['x'], { workDir: TMP_ROOT })
     const args = mocks.convertMock.mock.calls[0]![1] as Record<string, unknown>
     expect(args).not.toHaveProperty('voiceSettings')
   })
@@ -100,17 +109,24 @@ describe('OpenAIProvider', () => {
     mocks.openaiCreateMock.mockResolvedValue({ arrayBuffer: async () => new ArrayBuffer(3) })
   })
 
-  it('sends voice, model, and speed from factory config', async () => {
+  it('sends voice, model, and speed from factory config (per text in batch)', async () => {
     const p = OpenAIProvider({ apiKey: 'k', voice: 'nova', model: 'tts-1', speed: 1.1 })
-    await p.synthesize('hi')
-    expect(mocks.openaiCreateMock).toHaveBeenCalledWith(expect.objectContaining({
+    const results = await p.synthesize(['hi', 'there'], { workDir: TMP_ROOT })
+    expect(results).toHaveLength(2)
+    expect(results[0]!.path).toMatch(/openai-.*\.mp3$/)
+    expect(fs.existsSync(results[0]!.path)).toBe(true)
+    expect(mocks.openaiCreateMock).toHaveBeenCalledTimes(2)
+    expect(mocks.openaiCreateMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
       voice: 'nova', model: 'tts-1', speed: 1.1, input: 'hi', response_format: 'mp3',
+    }))
+    expect(mocks.openaiCreateMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      input: 'there',
     }))
   })
 
   it('options override factory config per call', async () => {
     const p = OpenAIProvider({ apiKey: 'k', voice: 'nova', model: 'tts-1', speed: 1.1 })
-    await p.synthesize('hi', { voice: 'echo', model: 'tts-2', speed: 0.9 })
+    await p.synthesize(['hi'], { workDir: TMP_ROOT, voice: 'echo', model: 'tts-2', speed: 0.9 })
     expect(mocks.openaiCreateMock).toHaveBeenCalledWith(expect.objectContaining({
       voice: 'echo', model: 'tts-2', speed: 0.9,
     }))
@@ -118,13 +134,13 @@ describe('OpenAIProvider', () => {
 
   it('adds instructions from factory config when provided', async () => {
     const p = OpenAIProvider({ apiKey: 'k', instructions: 'be calm' })
-    await p.synthesize('x')
+    await p.synthesize(['x'], { workDir: TMP_ROOT })
     expect(mocks.openaiCreateMock).toHaveBeenCalledWith(expect.objectContaining({ instructions: 'be calm' }))
   })
 
   it('omits instructions when not provided', async () => {
     const p = OpenAIProvider({ apiKey: 'k' })
-    await p.synthesize('x')
+    await p.synthesize(['x'], { workDir: TMP_ROOT })
     const args = mocks.openaiCreateMock.mock.calls[0]![0] as Record<string, unknown>
     expect(args).not.toHaveProperty('instructions')
   })
@@ -141,15 +157,19 @@ describe('PollyProvider', () => {
     })
   })
 
-  it('sends voice, engine, and languageCode from factory config', async () => {
+  it('sends voice, engine, and languageCode for each text in the batch', async () => {
     const p = PollyProvider({
       region: 'us-east-1', accessKeyId: 'a', secretAccessKey: 's',
       voice: 'Joanna', engine: 'neural', languageCode: 'en-US',
     })
-    await p.synthesize('hi')
+    const results = await p.synthesize(['hi', 'there'], { workDir: TMP_ROOT })
+    expect(results).toHaveLength(2)
+    expect(results[0]!.path).toMatch(/polly-.*\.mp3$/)
+    expect(fs.existsSync(results[0]!.path)).toBe(true)
     expect(mocks.pollyCommandCalls[0]).toMatchObject({
       Text: 'hi', VoiceId: 'Joanna', Engine: 'neural', LanguageCode: 'en-US',
     })
+    expect(mocks.pollyCommandCalls[1]).toMatchObject({ Text: 'there' })
   })
 
   it('voice and languageCode options override config per call', async () => {
@@ -157,7 +177,7 @@ describe('PollyProvider', () => {
       region: 'us-east-1', accessKeyId: 'a', secretAccessKey: 's',
       voice: 'Joanna', languageCode: 'en-US',
     })
-    await p.synthesize('hi', { voice: 'Matthew', languageCode: 'en-GB' })
+    await p.synthesize(['hi'], { workDir: TMP_ROOT, voice: 'Matthew', languageCode: 'en-GB' })
     expect(mocks.pollyCommandCalls[0]).toMatchObject({
       VoiceId: 'Matthew', LanguageCode: 'en-GB',
     })
@@ -166,6 +186,6 @@ describe('PollyProvider', () => {
   it('throws when Polly returns no AudioStream', async () => {
     mocks.pollySendMock.mockResolvedValueOnce({})
     const p = PollyProvider({ region: 'us-east-1', accessKeyId: 'a', secretAccessKey: 's' })
-    await expect(p.synthesize('x')).rejects.toThrow(/no audio stream/i)
+    await expect(p.synthesize(['x'], { workDir: TMP_ROOT })).rejects.toThrow(/no audio stream/i)
   })
 })

--- a/tests/unit/voiceover/qwen.test.ts
+++ b/tests/unit/voiceover/qwen.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { QwenTtsProvider } from '../../../src/voiceover/providers/qwen'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const TMP = path.join(os.tmpdir(), `qwen-provider-test-${process.pid}`)
+const STUB_SCRIPT = path.resolve(__dirname, '../../fixtures/qwen-stub.py')
+
+beforeAll(() => fs.mkdirSync(TMP, { recursive: true }))
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }))
+
+function makeVoiceSample(dir: string, name = 'voice.wav', bytes = Buffer.from('VOICE')): string {
+  const p = path.join(dir, name)
+  fs.writeFileSync(p, bytes)
+  return p
+}
+
+describe('QwenTtsProvider config validation', () => {
+  it('clone mode requires voiceSample', () => {
+    expect(() => QwenTtsProvider({
+      mode: 'clone',
+      // @ts-expect-error voiceSample missing on purpose
+      refText: 'hi',
+    })).toThrow(/voiceSample/)
+  })
+
+  it('clone mode requires refText', () => {
+    expect(() => QwenTtsProvider({
+      mode: 'clone',
+      // @ts-expect-error refText missing on purpose
+      voiceSample: '/tmp/x.wav',
+    })).toThrow(/refText/)
+  })
+
+  it('design mode requires voiceDescription', () => {
+    expect(() => QwenTtsProvider({
+      mode: 'design',
+      // @ts-expect-error voiceDescription missing on purpose
+      refText: 'hi',
+    })).toThrow(/voiceDescription/)
+  })
+
+  it('design mode requires refText', () => {
+    expect(() => QwenTtsProvider({
+      mode: 'design',
+      // @ts-expect-error refText missing on purpose
+      voiceDescription: 'a calm voice',
+    })).toThrow(/refText/)
+  })
+
+  it('clone-mode provider exposes name "qwen"', () => {
+    const samplePath = path.join(TMP, 'name-test-voice.wav')
+    fs.writeFileSync(samplePath, Buffer.from('VOICE'))
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample: samplePath,
+      refText: 'hi',
+    })
+    expect(p.name).toBe('qwen')
+  })
+
+  it('design-mode provider exposes name "qwen"', () => {
+    const p = QwenTtsProvider({
+      mode: 'design',
+      voiceDescription: 'a calm voice',
+      refText: 'hi',
+    })
+    expect(p.name).toBe('qwen')
+  })
+
+  it('isAvailable returns true (no api key needed)', async () => {
+    const samplePath = path.join(TMP, 'avail-test-voice.wav')
+    fs.writeFileSync(samplePath, Buffer.from('VOICE'))
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample: samplePath,
+      refText: 'hi',
+    })
+    expect(await p.isAvailable()).toBe(true)
+  })
+})
+
+describe('QwenTtsProvider synthesize() — clone mode through stub sidecar', () => {
+  it('writes one MP3 per input text and returns paths in order', async () => {
+    const workDir = path.join(TMP, 'work-clone-basic')
+    fs.mkdirSync(workDir, { recursive: true })
+    const voiceSample = makeVoiceSample(workDir)
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+    const out = await p.synthesize(['first', 'second'], { workDir })
+
+    expect(out).toHaveLength(2)
+    expect(out[0]!.path.endsWith('.mp3')).toBe(true)
+    expect(fs.existsSync(out[0]!.path)).toBe(true)
+    expect(fs.existsSync(out[1]!.path)).toBe(true)
+    expect(out[0]!.format.codec).toBe('mp3')
+  })
+})
+
+describe('QwenTtsProvider synthesize() — audio cache', () => {
+  it('with cacheAudio:true, second call skips the sidecar', async () => {
+    const workDir = path.join(TMP, 'work-cache-hit')
+    fs.mkdirSync(workDir, { recursive: true })
+    const cacheDir = path.join(TMP, 'cache-hit')
+    const voiceSample = makeVoiceSample(workDir)
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: true,
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+
+    const first = await p.synthesize(['hello'], { workDir })
+    // With the ephemeral-copy contract, returned path is under workDir (not cacheDir/audio).
+    expect(first[0]!.path.startsWith(workDir)).toBe(true)
+    expect(fs.existsSync(first[0]!.path)).toBe(true)
+
+    // Make the stub fail if it's invoked the second time — proves cache hit.
+    const failingStub = path.join(TMP, 'failing-stub.py')
+    fs.writeFileSync(failingStub, 'import sys\nsys.exit(99)\n')
+    const p2 = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: true,
+      __pythonScriptPath__: failingStub,
+    })
+    const second = await p2.synthesize(['hello'], { workDir })
+    // Both calls returned ephemeral paths under workDir; the cache is what matters.
+    expect(second[0]!.path.startsWith(workDir)).toBe(true)
+  })
+
+  it('with cacheAudio:false, output goes under workDir not cacheDir', async () => {
+    const workDir = path.join(TMP, 'work-no-cache')
+    fs.mkdirSync(workDir, { recursive: true })
+    const cacheDir = path.join(TMP, 'cache-no-cache')
+    const voiceSample = makeVoiceSample(workDir)
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: false,
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+
+    const out = await p.synthesize(['hello'], { workDir })
+    expect(out[0]!.path.startsWith(workDir)).toBe(true)
+    expect(fs.existsSync(path.join(cacheDir, 'audio'))).toBe(false)
+  })
+
+  it('with duplicate texts, only one is sent to the sidecar; both indices share the same MP3', async () => {
+    const workDir = path.join(TMP, 'work-dup')
+    fs.mkdirSync(workDir, { recursive: true })
+    const cacheDir = path.join(TMP, 'cache-dup')
+    const voiceSample = makeVoiceSample(workDir)
+
+    // Counting stub: records the number of clone.texts it saw to a file
+    const countFile = path.join(TMP, 'dup-count.txt')
+    const countingStub = path.join(TMP, 'counting-stub.py')
+    fs.writeFileSync(countingStub, [
+      'import json, sys, struct, wave',
+      'req = json.loads(sys.stdin.read())',
+      'with open(' + JSON.stringify(countFile) + ', "w") as f: f.write(str(len(req["clone"]["texts"])))',
+      'work = req["workDir"]',
+      'results = {"ok": True, "clone": []}',
+      'for i, _ in enumerate(req["clone"]["texts"]):',
+      '    p = f"{work}/clone-{i}.wav"',
+      '    with wave.open(p, "wb") as w:',
+      '        w.setnchannels(1); w.setsampwidth(2); w.setframerate(24000)',
+      '        w.writeframes(struct.pack("<" + "h" * 1000, *([0] * 1000)))',
+      '    results["clone"].append({"path": p})',
+      'print(json.dumps(results))',
+    ].join('\n'))
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: true,
+      __pythonScriptPath__: countingStub,
+    })
+
+    const out = await p.synthesize(['hello', 'hello', 'world'], { workDir })
+    expect(out).toHaveLength(3)
+    // Duplicates get separate ephemeral copies (so each can be independently renamed by the processor).
+    expect(out[0]!.path).not.toBe(out[1]!.path)
+    // But the files are byte-identical (same underlying audio).
+    expect(fs.readFileSync(out[0]!.path)).toEqual(fs.readFileSync(out[1]!.path))
+    expect(out[2]!.path).not.toBe(out[0]!.path)
+    expect(fs.readFileSync(countFile, 'utf8')).toBe('2')  // only 'hello' + 'world' sent to sidecar
+  })
+
+  it('after generateVoiceover-style consumption of audio.path, the cache file still exists', async () => {
+    const workDir = path.join(TMP, 'work-cache-survives')
+    fs.mkdirSync(workDir, { recursive: true })
+    const cacheDir = path.join(TMP, 'cache-survives')
+    const voiceSample = makeVoiceSample(workDir)
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: true,
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+
+    const out = await p.synthesize(['hello'], { workDir })
+    expect(out[0]!.path.startsWith(workDir)).toBe(true)  // returned path is ephemeral, in workDir
+
+    // Simulate what generateVoiceover does: move the returned file.
+    const consumed = path.join(workDir, 'consumed.mp3')
+    fs.renameSync(out[0]!.path, consumed)
+
+    // The cache file must still exist for a future run to hit it.
+    const cacheFiles = fs.readdirSync(path.join(cacheDir, 'audio'))
+    expect(cacheFiles).toHaveLength(1)
+    expect(cacheFiles[0]!.endsWith('.mp3')).toBe(true)
+  })
+})
+
+describe('QwenTtsProvider synthesize() — design mode', () => {
+  it('without design cache, runs design + clone in one sidecar call', async () => {
+    const workDir = path.join(TMP, 'work-design-fresh')
+    fs.mkdirSync(workDir, { recursive: true })
+    const cacheDir = path.join(TMP, 'cache-design-fresh')
+
+    const p = QwenTtsProvider({
+      mode: 'design',
+      voiceDescription: 'A calm male voice',
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: true,
+      cacheVoiceDesign: true,
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+
+    const out = await p.synthesize(['hello'], { workDir })
+
+    expect(out).toHaveLength(1)
+    expect(fs.existsSync(out[0]!.path)).toBe(true)
+    // Design WAV should have been moved into the cache.
+    const designDir = path.join(cacheDir, 'design')
+    expect(fs.existsSync(designDir)).toBe(true)
+    expect(fs.readdirSync(designDir).filter((f) => f.endsWith('.wav'))).toHaveLength(1)
+  })
+
+  it('with design cache present, subsequent call uses cached design WAV (no design block sent)', async () => {
+    const workDir = path.join(TMP, 'work-design-reuse')
+    fs.mkdirSync(workDir, { recursive: true })
+    const cacheDir = path.join(TMP, 'cache-design-reuse')
+
+    const p1 = QwenTtsProvider({
+      mode: 'design',
+      voiceDescription: 'A calm male voice',
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: false, // force clone work both times
+      cacheVoiceDesign: true,
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+    await p1.synthesize(['hello'], { workDir })
+
+    // A stub that fails if 'design' is in the request — proves no design was sent.
+    const designSentinelStub = path.join(TMP, 'design-sentinel.py')
+    fs.writeFileSync(designSentinelStub, [
+      'import json, sys, struct, wave',
+      'req = json.loads(sys.stdin.read())',
+      'assert "design" not in req, "design block leaked through cache"',
+      'work = req["workDir"]',
+      'results = {"ok": True, "clone": []}',
+      'for i, _ in enumerate(req["clone"]["texts"]):',
+      '    p = f"{work}/clone-{i}.wav"',
+      '    with wave.open(p, "wb") as w:',
+      '        w.setnchannels(1); w.setsampwidth(2); w.setframerate(24000)',
+      '        w.writeframes(struct.pack("<" + "h" * 1000, *([0] * 1000)))',
+      '    results["clone"].append({"path": p})',
+      'print(json.dumps(results))',
+    ].join('\n'))
+
+    const p2 = QwenTtsProvider({
+      mode: 'design',
+      voiceDescription: 'A calm male voice',
+      refText: 'Welcome',
+      cacheDir,
+      cacheAudio: false,
+      cacheVoiceDesign: true,
+      __pythonScriptPath__: designSentinelStub,
+    })
+    await expect(p2.synthesize(['hello'], { workDir })).resolves.toBeDefined()
+  })
+})
+
+describe('QwenTtsProvider synthesize() — sidecar errors', () => {
+  it('sidecar reporting ok=false at stage=clone throws QwenSidecarError with stage', async () => {
+    const workDir = path.join(TMP, 'work-err-clone')
+    fs.mkdirSync(workDir, { recursive: true })
+    const voiceSample = makeVoiceSample(workDir)
+
+    // Use a tiny inline script that emits an ok:false JSON.
+    const failingStub = path.join(TMP, 'err-stub-clone.py')
+    fs.writeFileSync(failingStub, [
+      'import json, sys',
+      'print(json.dumps({"ok": False, "stage": "clone", "error": "boom", "traceback": "..."}))',
+      'sys.exit(1)',
+    ].join('\n'))
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      __pythonScriptPath__: failingStub,
+    })
+
+    const err = await p.synthesize(['hello'], { workDir }).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('QwenSidecarError')
+    expect(err.stage).toBe('clone')
+    expect(err.message).toContain('boom')
+  })
+
+  it('missing pythonBin yields a clear error message', async () => {
+    const workDir = path.join(TMP, 'work-no-python')
+    fs.mkdirSync(workDir, { recursive: true })
+    const voiceSample = makeVoiceSample(workDir)
+
+    const p = QwenTtsProvider({
+      mode: 'clone',
+      voiceSample,
+      refText: 'Welcome',
+      pythonBin: '/non/existent/python-binary-xyz',
+      __pythonScriptPath__: STUB_SCRIPT,
+    })
+
+    await expect(p.synthesize(['hello'], { workDir })).rejects.toThrow(
+      /could not spawn .*python-binary-xyz/i,
+    )
+  })
+})

--- a/tests/unit/voiceover/util.test.ts
+++ b/tests/unit/voiceover/util.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { resolveWorkDir } from '../../../src/voiceover/providers/util/resolveWorkDir'
+import { writeAudioSegment } from '../../../src/voiceover/providers/util/writeAudioSegment'
+
+const TMP_ROOT = path.join(os.tmpdir(), `recast-util-test-${process.pid}`)
+
+beforeAll(() => fs.mkdirSync(TMP_ROOT, { recursive: true }))
+afterAll(() => fs.rmSync(TMP_ROOT, { recursive: true, force: true }))
+
+describe('resolveWorkDir', () => {
+  it('returns os.tmpdir() when workDir is undefined', () => {
+    const dir = resolveWorkDir(undefined)
+    expect(dir).toBe(os.tmpdir())
+    expect(fs.existsSync(dir)).toBe(true)
+  })
+
+  it('returns the given workDir and creates it if missing', () => {
+    const target = path.join(TMP_ROOT, 'new-nested', 'workdir')
+    expect(fs.existsSync(target)).toBe(false)
+
+    const dir = resolveWorkDir(target)
+
+    expect(dir).toBe(target)
+    expect(fs.existsSync(target)).toBe(true)
+    expect(fs.statSync(target).isDirectory()).toBe(true)
+  })
+
+  it('is idempotent — calling twice on an existing dir does not throw', () => {
+    const target = path.join(TMP_ROOT, 'idempotent')
+    expect(() => {
+      resolveWorkDir(target)
+      resolveWorkDir(target)
+    }).not.toThrow()
+  })
+})
+
+describe('writeAudioSegment', () => {
+  it('writes the buffer to <dir>/<prefix>-<uuid>.<ext> with mp3 defaults', async () => {
+    const buf = Buffer.from('FAKE_MP3_BYTES')
+    const seg = await writeAudioSegment(buf, {
+      dir: TMP_ROOT,
+      prefix: 'testprov',
+      sampleRate: 24000,
+    })
+
+    expect(seg.path).toMatch(
+      new RegExp(`${path.basename(TMP_ROOT)}/testprov-[0-9a-f-]+\\.mp3$`),
+    )
+    expect(fs.readFileSync(seg.path)).toEqual(buf)
+    expect(seg.durationMs).toBe(0)
+    expect(seg.format).toEqual({ sampleRate: 24000, channels: 1, codec: 'mp3' })
+  })
+
+  it('honors custom codec, ext, and channels', async () => {
+    const buf = Buffer.from('FAKE_WAV')
+    const seg = await writeAudioSegment(buf, {
+      dir: TMP_ROOT,
+      prefix: 'wavprov',
+      sampleRate: 48000,
+      codec: 'pcm_s16le',
+      ext: 'wav',
+      channels: 2,
+    })
+
+    expect(seg.path.endsWith('.wav')).toBe(true)
+    expect(seg.format).toEqual({ sampleRate: 48000, channels: 2, codec: 'pcm_s16le' })
+  })
+
+  it('uses codec as the file extension by default', async () => {
+    const buf = Buffer.from('OGG')
+    const seg = await writeAudioSegment(buf, {
+      dir: TMP_ROOT,
+      prefix: 'ogg',
+      sampleRate: 48000,
+      codec: 'opus',
+    })
+
+    expect(seg.path.endsWith('.opus')).toBe(true)
+    expect(seg.format.codec).toBe('opus')
+  })
+
+  it('generates unique paths across successive calls', async () => {
+    const buf = Buffer.from('X')
+    const a = await writeAudioSegment(buf, { dir: TMP_ROOT, prefix: 'uniq', sampleRate: 24000 })
+    const b = await writeAudioSegment(buf, { dir: TMP_ROOT, prefix: 'uniq', sampleRate: 24000 })
+
+    expect(a.path).not.toBe(b.path)
+    expect(fs.existsSync(a.path)).toBe(true)
+    expect(fs.existsSync(b.path)).toBe(true)
+  })
+})

--- a/tests/unit/voiceover/voiceover-processor.test.ts
+++ b/tests/unit/voiceover/voiceover-processor.test.ts
@@ -3,6 +3,7 @@ import { execFileSync, spawnSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import * as crypto from 'node:crypto'
 import { generateVoiceover } from '../../../src/voiceover/voiceover-processor'
 import type { TtsProvider } from '../../../src/types/voiceover'
 import type { SubtitledTrace } from '../../../src/types/subtitle'
@@ -38,9 +39,19 @@ function levelAlternatingProvider(buffers: Buffer[]): TtsProvider {
   let i = 0
   return {
     name: 'fake-alt',
-    async synthesize() {
-      const data = buffers[i++ % buffers.length]!
-      return { data, durationMs: 0, format: { sampleRate: 44100, channels: 1, codec: 'mp3' } }
+    async synthesize(texts: string[], options) {
+      const dir = options?.workDir ?? TMP_ROOT
+      fs.mkdirSync(dir, { recursive: true })
+      return texts.map(() => {
+        const data = buffers[i++ % buffers.length]!
+        const filePath = path.join(dir, `fake-${crypto.randomUUID()}.mp3`)
+        fs.writeFileSync(filePath, data)
+        return {
+          path: filePath,
+          durationMs: 0,
+          format: { sampleRate: 44100, channels: 1, codec: 'mp3' },
+        }
+      })
     },
     estimateDurationMs() { return 0 },
     async isAvailable() { return true },
@@ -58,6 +69,32 @@ function makeTrace(subtitleCount: number): SubtitledTrace {
   }))
   return { subtitles: subs } as unknown as SubtitledTrace
 }
+
+describe('generateVoiceover provider length guard', () => {
+  beforeAll(() => { fs.mkdirSync(TMP_ROOT, { recursive: true }) })
+  afterAll(() => { fs.rmSync(TMP_ROOT, { recursive: true, force: true }) })
+
+  it('throws when provider returns fewer segments than texts', async () => {
+    const shortProvider: TtsProvider = {
+      name: 'short-provider',
+      async synthesize(_texts, options) {
+        const dir = options?.workDir ?? TMP_ROOT
+        fs.mkdirSync(dir, { recursive: true })
+        // Return only one item regardless of how many texts were requested
+        const filePath = path.join(dir, `fake-${crypto.randomUUID()}.mp3`)
+        fs.writeFileSync(filePath, Buffer.alloc(0))
+        return [{ path: filePath, durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } }]
+      },
+      estimateDurationMs() { return 0 },
+      async isAvailable() { return true },
+      async dispose() {},
+    }
+
+    const trace = makeTrace(3)
+    const tmp = path.join(TMP_ROOT, 'length-guard')
+    await expect(generateVoiceover(trace, shortProvider, tmp)).rejects.toThrow('returned')
+  })
+})
 
 describe('generateVoiceover with VoiceoverOptions.normalize', () => {
   beforeAll(() => { fs.mkdirSync(TMP_ROOT, { recursive: true }) })

--- a/website/components/landing/hero.tsx
+++ b/website/components/landing/hero.tsx
@@ -135,7 +135,7 @@ export function Hero() {
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
             </span>
-            <span className="truncate">v0.16.0 — self-contained narrate / highlight / zoom helpers</span>
+            <span className="truncate">v0.17.0 — local TTS with Qwen3-TTS voice clone &amp; design</span>
           </div>
         </BlurFade>
 

--- a/website/content/docs/api-reference/types.mdx
+++ b/website/content/docs/api-reference/types.mdx
@@ -317,12 +317,17 @@ interface ZoomKeyframe {
 
 ### `TtsProvider`
 
-The contract every TTS provider must implement.
+The contract every TTS provider must implement. `synthesize` is **batch-first** — it receives the full subtitle text array and returns one `AudioSegment` per input. Providers that want per-segment concurrency can do their own `Promise.all` fan-out internally.
 
 ```typescript
 interface TtsProvider {
   readonly name: string
-  synthesize(text: string, options?: TtsOptions): Promise<AudioSegment>
+  /**
+   * Synthesize speech for each text in `texts`. Returns one AudioSegment per
+   * input text, in order. Each segment's `path` points to a file on disk
+   * written by the provider (typically under `options.workDir`).
+   */
+  synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]>
   estimateDurationMs(text: string, options?: TtsOptions): number
   isAvailable(): Promise<boolean>
   dispose(): Promise<void>
@@ -331,11 +336,11 @@ interface TtsProvider {
 
 ### `AudioSegment`
 
-A chunk of synthesized audio.
+A chunk of synthesized audio. The provider writes the audio to disk and returns the path — the consumer (pipeline) owns cleanup of `options.workDir`.
 
 ```typescript
 interface AudioSegment {
-  data: Buffer
+  path: string
   durationMs: number
   format: {
     sampleRate: number
@@ -347,12 +352,22 @@ interface AudioSegment {
 
 ### `TtsOptions`
 
+Per-call overrides applied on top of the provider factory's defaults.
+
 ```typescript
 interface TtsOptions {
+  /** Voice id/name override (provider-specific) */
   voice?: string
+  /** Model id override (provider-specific) */
+  model?: string
+  /** BCP-47 language code override (e.g. 'cs', 'en-US') */
+  languageCode?: string
+  /** Playback speed multiplier (1.0 = natural) */
   speed?: number
+  /** Output audio format hint */
   format?: 'mp3' | 'wav' | 'opus' | 'pcm'
-  locale?: string
+  /** Directory the provider should write output files into. Caller owns cleanup. */
+  workDir?: string
 }
 ```
 

--- a/website/content/docs/providers/meta.json
+++ b/website/content/docs/providers/meta.json
@@ -1,1 +1,1 @@
-{"title": "TTS Providers", "pages": ["openai", "elevenlabs", "polly"]}
+{"title": "TTS Providers", "pages": ["openai", "elevenlabs", "polly", "qwen"]}

--- a/website/content/docs/providers/qwen.mdx
+++ b/website/content/docs/providers/qwen.mdx
@@ -1,0 +1,180 @@
+---
+title: Qwen3-TTS (local, GPU)
+description: Generate voiceover narration locally on a CUDA GPU using Alibaba's Qwen3-TTS models.
+---
+
+`QwenTtsProvider` runs TTS locally via Alibaba's Qwen3-TTS family. It supports two modes:
+
+- **Clone** — synthesize text in the voice of a reference WAV/MP3 (`voiceSample`).
+- **Design** — synthesize text in a voice described by a prompt (`voiceDescription`). The provider first generates a reference WAV from the description, then clones it for every subtitle.
+
+A Python sidecar (PyTorch + `qwen-tts` + `flash-attn`) is spawned once per pipeline run and held open across the whole subtitle batch.
+
+## Requirements
+
+- **CUDA-capable GPU** — ~4–8 GB VRAM depending on model.
+- **Python 3** — invoked via the path you pass as `pythonBin`.
+- **`HF_TOKEN`** in the environment if the chosen weights are gated.
+
+No npm peer dependency is required — the provider talks to the sidecar over stdin/stdout JSON.
+
+## Python environment setup
+
+The sidecar's stack (PyTorch + `flash-attn` + Qwen) is **~5–8 GB on disk**, so where you install it matters. pip caches *downloads* in `~/.cache/pip`, but *installs* are copied into each venv's `site-packages` — so a per-project venv with PyTorch costs ~5–8 GB **per project**.
+
+### Recommended: one shared venv reused across projects
+
+```bash
+python3 -m venv ~/.venvs/qwen-tts
+~/.venvs/qwen-tts/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+```
+
+```typescript
+QwenTtsProvider({
+  mode: 'clone',
+  voiceSample: './my-voice.wav',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+})
+```
+
+Absolute `pythonBin` works regardless of shell activation — useful for CI, cron, and IDE runners.
+
+### Alternative: `uv` (most disk-efficient)
+
+[`uv`](https://github.com/astral-sh/uv) hardlinks every venv from a global wheel store, so per-project `.venv`s cost almost nothing on disk:
+
+```bash
+uv venv ~/.venvs/qwen-tts
+uv pip install --python ~/.venvs/qwen-tts/bin/python -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+```
+
+If you've got `uv` installed, even a per-project `.venv` is reasonable — the hardlinks deduplicate PyTorch automatically.
+
+### Alternative: per-project `.venv` (full isolation)
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+```
+
+Then `pythonBin: '.venv/bin/python3'`. Cleanest isolation; pay ~5–8 GB per project unless paired with `uv`.
+
+### Conda
+
+Works the same way — point `pythonBin` at the env's `bin/python3` (or `.../envs/<name>/bin/python3`).
+
+### `flash-attn` build notes
+
+`flash-attn` needs a CUDA toolchain at install time. If no precompiled wheel matches your CUDA/PyTorch combo, follow the build instructions at [Dao-AILab/flash-attention](https://github.com/Dao-AILab/flash-attention).
+
+## Usage — clone mode
+
+```typescript
+import { Recast } from 'playwright-recast'
+import { QwenTtsProvider } from 'playwright-recast/providers/qwen'
+
+await Recast
+  .from('./traces')
+  .parse()
+  .subtitlesFromSrt('./narration.srt')
+  .voiceover(QwenTtsProvider({
+    mode: 'clone',
+    voiceSample: './my-voice.wav',
+    refText: 'Welcome! In this screencast we will walk through the key concepts.',
+    language: 'English',
+    cacheAudio: true,
+  }))
+  .render({ format: 'mp4' })
+  .toFile('demo.mp4')
+```
+
+`refText` is the **literal transcript** of `voiceSample` — Qwen needs both to clone the voice correctly. Get it best by re-recording the line yourself, or by transcribing the sample with whisper.
+
+## Usage — design mode
+
+```typescript
+.voiceover(QwenTtsProvider({
+  mode: 'design',
+  voiceDescription: 'A clear, steady male voice with a calm and even tone.',
+  refText: 'Welcome! In this screencast we will walk through the key concepts.',
+  language: 'English',
+  cacheAudio: true,
+  cacheVoiceDesign: true,           // reuse the generated reference WAV across runs
+}))
+```
+
+In design mode `refText` is the line the model will speak *into* the reference WAV — it doesn't transcribe an existing file. Pick something close in tone and length to your actual narration.
+
+## Configuration options
+
+### Common
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `mode` | `'clone' \| 'design'` | (required) | Which sub-API to use |
+| `refText` | `string` | (required) | Reference text (transcript in clone mode; prompt in design mode) |
+| `language` | `string` | `'English'` | Generation language — pass the Qwen language name (`'English'`, `'German'`, `'Chinese'`, …) |
+| `cloneModel` | `string` | `'Qwen/Qwen3-TTS-12Hz-0.6B-Base'` | HuggingFace model ID for cloning |
+| `cacheDir` | `string` | `'./.recast-cache/voice'` | Where cached artifacts are written |
+| `cacheAudio` | `boolean` | `false` | Cache per-segment MP3s |
+| `pythonBin` | `string` | `'python3'` | Python interpreter to launch the sidecar |
+| `device` | `string` | `'cuda:0'` | Torch device |
+| `dtype` | `'bfloat16' \| 'float16' \| 'float32'` | `'bfloat16'` | Model precision |
+
+### Clone mode
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `voiceSample` | `string` | Path to a `.wav` / `.mp3` of the voice you want to clone |
+
+### Design mode
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `voiceDescription` | `string` | (required) | Natural-language description of the target voice |
+| `designModel` | `string` | `'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign'` | HuggingFace model ID for voice design |
+| `cacheVoiceDesign` | `boolean` | `false` | Cache the generated reference WAV across runs |
+
+## Caching
+
+Caching is **opt-in**, both flags default off:
+
+| Flag | What it caches | Hash includes |
+|------|----------------|---------------|
+| `cacheAudio` | Per-segment MP3s at `cacheDir/audio/<hash>.mp3` | target text, refText, ref-audio fingerprint, language, model, dtype |
+| `cacheVoiceDesign` (design only) | The generated reference WAV at `cacheDir/design/<hash>.wav` | description, refText, language, designModel, dtype |
+
+`cacheDir` defaults to `./.recast-cache/voice`. The cache grows unbounded — manage retention yourself.
+
+In clone mode, the ref-audio fingerprint is a deterministic hash over the *contents* of `voiceSample`, so swapping the file (even keeping the same path) correctly invalidates the cache.
+
+## Error handling
+
+Sidecar failures surface as `QwenSidecarError` with a `stage` field:
+
+| `stage` | Meaning |
+|---------|---------|
+| `init` | Missing Python deps, malformed request, or CUDA / model load failure |
+| `design` | Voice design (design mode only) failed |
+| `clone` | Per-segment synthesis failed |
+
+```typescript
+import { QwenSidecarError } from 'playwright-recast/providers/qwen'
+
+try {
+  await pipeline.toFile('demo.mp4')
+} catch (err) {
+  if (err instanceof QwenSidecarError) {
+    console.error(`Qwen failed at ${err.stage}:`, err.message)
+    console.error(err.pythonTraceback)
+  }
+  throw err
+}
+```
+
+## Notes
+
+- The sidecar process is held open for the full subtitle batch — model load happens once, not per line.
+- Output is always MP3 at the Qwen sample rate (12 kHz native, re-encoded by the sidecar).
+- No CLI flag yet — wire it up programmatically.


### PR DESCRIPTION
## Summary
     
  - New **`QwenTtsProvider`** (clone + design modes) backed by a Python sidecar; CLI support via `--provider qwen --qwen-config <path>` reading a JSON config
  - Refactored provider utilities into `src/voiceover/providers/util/` (`resolveWorkDir`, `writeAudioSegment`, `hashValues`, `hashFile`); elevenlabs / openai / polly migrated to use them — fewer per-provider duplications, one `AudioSegment` construction site
  - Docs (README + website + Claude skill + sidecar README) lead with a shared `~/.venvs/qwen-tts` for the ~5–8 GB CUDA stack, with `uv`, per-project `.venv`, and conda as alternatives — always passing the venv's `bin/python3` as an absolute `pythonBin` so no shell activation is needed
  
  ## Breaking changes
  
  - `TtsProvider.synthesize()` is now **batch-first**: takes `string[]` and returns `AudioSegment[]` (path-based, not inline buffer). Migrate single-text callers by wrapping the input as `[text]` and reading `result[0].path`. All bundled providers are migrated.
  
  ## Implementation notes
  
  - The sidecar is held open for the whole subtitle batch (one model load per pipeline, not per line). The synthesis loop deduplicates identical texts within a batch, so re-used narration is synthesized once and copied for the siblings.
  - Cache keys are SHA-256 over `[text, language, cloneModel, dtype, refText, refAudioFingerprint]`. The ref-audio fingerprint is a SHA-256 of the WAV contents in clone mode, or the design hash in design mode (so swapping the file invalidates the cache).
  - Packaging: a `.npmignore` inside `src/voiceover/providers/qwen-sidecar/` excludes `__pycache__` / `*.pyc` at publish time (a project-root `.npmignore` is overridden by the `files` whitelist, so in-directory placement is the only one npm actually honors). `prepublishOnly` is now just `tsc && cp -R … dist/voiceover/providers/`.
  - `synthesize()` is split into named phases — `planSynthesis`, `resolveRefAudio`, `buildSidecarRequest`, `persistDesignWav`, `persistCloneWavs`, `fillDuplicates`, `buildResult` — for readability.