### PR TITLE
refactor(voiceover)!: drop unused estimateDurationMs, gate synth on isAvailable

### DIFF
--- a/src/types/voiceover.ts
+++ b/src/types/voiceover.ts
@@ -39,7 +39,6 @@ export interface TtsProvider {
    * written by the provider (typically under `options.workDir`).
    */
   synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]>
-  estimateDurationMs(text: string, options?: TtsOptions): number
   isAvailable(): Promise<boolean>
   dispose(): Promise<void>
 }

--- a/src/voiceover/providers/elevenlabs.ts
+++ b/src/voiceover/providers/elevenlabs.ts
@@ -88,13 +88,14 @@ export function ElevenLabsProvider(config: ElevenLabsProviderConfig = {}): TtsPr
       }))
     },
 
-    estimateDurationMs(text: string): number {
-      const words = text.split(/\s+/).length
-      return (words / 150) * 60_000
-    },
-
     async isAvailable(): Promise<boolean> {
-      return !!apiKey
+      if (!apiKey) return false
+      try {
+        await import('@elevenlabs/elevenlabs-js')
+        return true
+      } catch {
+        return false
+      }
     },
 
     async dispose(): Promise<void> {

--- a/src/voiceover/providers/openai.ts
+++ b/src/voiceover/providers/openai.ts
@@ -71,14 +71,14 @@ export function OpenAIProvider(config: OpenAIProviderConfig = {}): TtsProvider {
       }))
     },
 
-    estimateDurationMs(text: string, options?: TtsOptions): number {
-      const spd = options?.speed ?? defaults.speed
-      const words = text.split(/\s+/).length
-      return (words / (150 * spd)) * 60_000
-    },
-
     async isAvailable(): Promise<boolean> {
-      return !!apiKey
+      if (!apiKey) return false
+      try {
+        await import('openai')
+        return true
+      } catch {
+        return false
+      }
     },
 
     async dispose(): Promise<void> {

--- a/src/voiceover/providers/polly.ts
+++ b/src/voiceover/providers/polly.ts
@@ -109,14 +109,13 @@ export function PollyProvider(config: PollyProviderConfig = {}): TtsProvider {
       }))
     },
 
-    estimateDurationMs(text: string, options?: TtsOptions): number {
-      const spd = options?.speed ?? 1.0
-      const words = text.split(/\s+/).length
-      return (words / (150 * spd)) * 60_000
-    },
-
     async isAvailable(): Promise<boolean> {
-      return true
+      try {
+        await import('@aws-sdk/client-polly')
+        return true
+      } catch {
+        return false
+      }
     },
 
     async dispose(): Promise<void> {

--- a/src/voiceover/providers/qwen.ts
+++ b/src/voiceover/providers/qwen.ts
@@ -371,13 +371,12 @@ export function QwenTtsProvider(config: QwenTtsProviderConfig): TtsProvider {
       }
     },
 
-    estimateDurationMs(text: string): number {
-      const words = text.split(/\s+/).length
-      return (words / 150) * 60_000
-    },
-
     async isAvailable(): Promise<boolean> {
-      return true
+      const r = spawnSync(pythonBin, ['--version'], { stdio: 'ignore' })
+      if (r.status !== 0) return false
+      const scriptPath = config.__pythonScriptPath__
+        ?? path.join(path.dirname(fileURLToPath(import.meta.url)), 'qwen-sidecar', 'sidecar.py')
+      return fs.existsSync(scriptPath)
     },
 
     async dispose(): Promise<void> {

--- a/src/voiceover/voiceover-processor.ts
+++ b/src/voiceover/voiceover-processor.ts
@@ -56,6 +56,13 @@ export async function generateVoiceover(
   fs.mkdirSync(tmpDir, { recursive: true })
   const normalizeConfig = resolveNormalize(options?.normalize)
 
+  if (!(await provider.isAvailable())) {
+    throw new Error(
+      `Voiceover provider "${provider.name}" is not available — ` +
+        `check credentials, peer-dependency installation, or runtime prerequisites.`,
+    )
+  }
+
   const texts = trace.subtitles.map((s) => s.ttsText ?? s.text)
   const audios = await provider.synthesize(texts, { workDir: tmpDir })
 

--- a/tests/unit/pipeline/pipeline.test.ts
+++ b/tests/unit/pipeline/pipeline.test.ts
@@ -94,7 +94,6 @@ describe('Pipeline (fluent chain)', () => {
     const mockProvider = {
       name: 'mock',
       synthesize: async (texts: string[]) => texts.map(() => ({ path: '', durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } })),
-      estimateDurationMs: () => 1000,
       isAvailable: async () => true,
       dispose: async () => {},
     }

--- a/tests/unit/pipeline/voiceover-stage.test.ts
+++ b/tests/unit/pipeline/voiceover-stage.test.ts
@@ -5,7 +5,6 @@ import type { TtsProvider } from '../../../src/types/voiceover'
 const fakeProvider: TtsProvider = {
   name: 'fake',
   async synthesize() { return [] },
-  estimateDurationMs() { return 0 },
   async isAvailable() { return true },
   async dispose() {},
 }

--- a/tests/unit/voiceover/voiceover-processor.test.ts
+++ b/tests/unit/voiceover/voiceover-processor.test.ts
@@ -53,7 +53,6 @@ function levelAlternatingProvider(buffers: Buffer[]): TtsProvider {
         }
       })
     },
-    estimateDurationMs() { return 0 },
     async isAvailable() { return true },
     async dispose() {},
   }
@@ -85,7 +84,6 @@ describe('generateVoiceover provider length guard', () => {
         fs.writeFileSync(filePath, Buffer.alloc(0))
         return [{ path: filePath, durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } }]
       },
-      estimateDurationMs() { return 0 },
       async isAvailable() { return true },
       async dispose() {},
     }

--- a/tests/unit/voiceover/voiceover-processor.test.ts
+++ b/tests/unit/voiceover/voiceover-processor.test.ts
@@ -69,6 +69,57 @@ function makeTrace(subtitleCount: number): SubtitledTrace {
   return { subtitles: subs } as unknown as SubtitledTrace
 }
 
+describe('generateVoiceover provider isAvailable guard', () => {
+  beforeAll(() => { fs.mkdirSync(TMP_ROOT, { recursive: true }) })
+  afterAll(() => { fs.rmSync(TMP_ROOT, { recursive: true, force: true }) })
+
+  it('throws an actionable error when provider.isAvailable() returns false', async () => {
+    let synthesizeCalled = false
+    const unavailableProvider: TtsProvider = {
+      name: 'unavailable-test',
+      async synthesize() {
+        synthesizeCalled = true
+        return []
+      },
+      async isAvailable() { return false },
+      async dispose() {},
+    }
+
+    const trace = makeTrace(1)
+    const tmp = path.join(TMP_ROOT, 'isavailable-guard')
+    await expect(generateVoiceover(trace, unavailableProvider, tmp)).rejects.toThrow(
+      /provider "unavailable-test" is not available/,
+    )
+    expect(synthesizeCalled).toBe(false)
+  })
+
+  it('proceeds to synthesize when isAvailable() returns true', async () => {
+    let synthesizeCalled = false
+    const okProvider: TtsProvider = {
+      name: 'ok-test',
+      async synthesize(texts, options) {
+        synthesizeCalled = true
+        const dir = options?.workDir ?? TMP_ROOT
+        fs.mkdirSync(dir, { recursive: true })
+        return texts.map(() => {
+          const p = path.join(dir, `ok-${crypto.randomUUID()}.mp3`)
+          fs.writeFileSync(p, Buffer.alloc(0))
+          return { path: p, durationMs: 0, format: { sampleRate: 24000, channels: 1, codec: 'mp3' } }
+        })
+      },
+      async isAvailable() { return true },
+      async dispose() {},
+    }
+
+    const trace = makeTrace(1)
+    const tmp = path.join(TMP_ROOT, 'isavailable-ok')
+    // Empty mp3s can't be probed for duration; we just want to confirm synthesize
+    // was reached before any downstream failure.
+    await generateVoiceover(trace, okProvider, tmp).catch(() => {})
+    expect(synthesizeCalled).toBe(true)
+  })
+})
+
 describe('generateVoiceover provider length guard', () => {
   beforeAll(() => { fs.mkdirSync(TMP_ROOT, { recursive: true }) })
   afterAll(() => { fs.rmSync(TMP_ROOT, { recursive: true, force: true }) })


### PR DESCRIPTION
## Summary
  - Remove the never-called `estimateDurationMs` from the `TtsProvider` interface and all four provider implementations.
  - `generateVoiceover` now awaits `provider.isAvailable()` before `synthesize()` and throws an actionable error when the provider is not configured.
  - Each provider now implements a meaningful availability check:
    - **openai / elevenlabs** — API key set AND peer dependency resolvable
    - **polly** — peer dependency resolvable (credentials deferred to AWS default chain)
    - **qwen** — configured Python binary spawns AND sidecar script exists
    
  ## Breaking change
  `TtsProvider` no longer requires `estimateDurationMs`. Custom provider implementations should drop the method.
