### PR TITLE
feat(providers): disk cache for ElevenLabs / OpenAI / Polly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.18.0 (2026-05-22)
+
+### Features
+
+- **Disk cache for `ElevenLabsProvider` / `OpenAIProvider` / `PollyProvider`** — Set `cacheDir` on any built-in provider and re-renders skip the API call for `(text, voice, model, language, settings)` tuples that have already been synthesized. Cache key is a SHA-256 over all audio-affecting inputs, so changing the voice / model / settings invalidates the entry. Saves API spend on iterative edits (re-render after subtitle tweaks → only the changed lines hit the API). Omit `cacheDir` to disable disk caching; intra-batch dedup (same narration reused twice in one render) still applies automatically.
+- **`synthesizeWithCache()` helper + `planBatch` primitives** — Exposed from `src/voiceover/providers/util/audio-cache.ts` for custom-provider authors. Wrap your single-text synthesis function and get cache + dedup for free with one call.
+
+### Internal
+
+- Refactored bundled providers (ElevenLabs / OpenAI / Polly) to share `synthesizeWithCache()` instead of hand-rolled `Promise.all` + buffer writes. Per-provider boilerplate dropped to a single `generateOne(text)` function.
+- Test suite: **410 passed** (+15 — 11 audio-cache helper tests + 4 per-provider cache tests).
+
 ## 0.17.0 (2026-05-22)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ OpenAIProvider({
   model: 'gpt-4o-mini-tts',
   speed: 1.2,
   instructions: 'Calm, professional demo narration.',
+  cacheDir: './.recast-cache/openai',  // optional: disk cache to skip re-synthesis
 })
 ```
 
@@ -329,6 +330,7 @@ ElevenLabsProvider({
     stability: 0.75,               // Higher = more consistent delivery (less drift)
     similarityBoost: 0.75,
   },
+  cacheDir: './.recast-cache/elevenlabs',  // optional: disk cache to skip re-synthesis
 })
 ```
 
@@ -344,6 +346,7 @@ PollyProvider({
   voice: 'Joanna',          // Matthew, Ruth, Stephen, Ivy, Joey, …
   engine: 'neural',         // standard | neural | long-form | generative
   sampleRate: '24000',
+  cacheDir: './.recast-cache/polly',  // optional: disk cache to skip re-synthesis
   // Credentials are optional — the AWS SDK default chain is used
   // (env vars, ~/.aws/credentials, IAM role on EC2/ECS/Lambda, SSO).
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-recast",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-recast",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-recast",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "description": "Fluent pipeline library for processing Playwright traces into polished demo videos — TTS voiceover, subtitles, speed control, and zoom.",
   "license": "MIT",

--- a/src/voiceover/providers/elevenlabs.ts
+++ b/src/voiceover/providers/elevenlabs.ts
@@ -1,6 +1,6 @@
+import * as os from 'node:os'
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
-import { resolveWorkDir } from './util/resolveWorkDir.js'
-import { writeAudioSegment } from './util/writeAudioSegment.js'
+import { synthesizeWithCache } from './util/audio-cache.js'
 
 export interface ElevenLabsVoiceSettings {
   stability?: number
@@ -19,6 +19,13 @@ export interface ElevenLabsProviderConfig {
   languageCode?: string
   /** Per-voice synthesis parameters. Omit to use the voice's dashboard defaults. */
   voiceSettings?: ElevenLabsVoiceSettings
+  /**
+   * Directory for disk caching of synthesized audio. When set, the provider
+   * skips API calls for `(text, voice, model, languageCode, voiceSettings)`
+   * tuples it has already synthesized. Omit to disable disk caching (the
+   * provider still dedups within a single batch).
+   */
+  cacheDir?: string
 }
 
 const DEFAULT_VOICE = 'onwK4e9ZLuTAKqWW03F9' // Daniel
@@ -61,20 +68,21 @@ export function ElevenLabsProvider(config: ElevenLabsProviderConfig = {}): TtsPr
 
     async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
       const el = await getClient()
-      const dir = resolveWorkDir(options?.workDir)
-      return Promise.all(texts.map(async (text) => {
-        const voice = options?.voice ?? defaults.voice
-        const model = options?.model ?? defaults.model
-        const languageCode = options?.languageCode ?? defaults.languageCode
+      const voice = options?.voice ?? defaults.voice
+      const model = options?.model ?? defaults.model
+      const languageCode = options?.languageCode ?? defaults.languageCode
+      const voiceSettings = defaults.voiceSettings
+      // Stable JSON for the fingerprint — undefined collapses to ''.
+      const voiceSettingsKey = voiceSettings ? JSON.stringify(voiceSettings) : ''
 
+      async function generateOne(text: string): Promise<Buffer> {
         const params: Record<string, unknown> = {
           text,
           modelId: model,
           outputFormat: 'mp3_44100_128',
         }
         if (languageCode) params.languageCode = languageCode
-        if (defaults.voiceSettings) params.voiceSettings = defaults.voiceSettings
-
+        if (voiceSettings) params.voiceSettings = voiceSettings
         const audio = await el.textToSpeech.convert(voice, params)
         const reader = audio.getReader()
         const chunks: Uint8Array[] = []
@@ -83,9 +91,20 @@ export function ElevenLabsProvider(config: ElevenLabsProviderConfig = {}): TtsPr
           if (done) break
           chunks.push(value)
         }
-        const buf = Buffer.concat(chunks)
-        return writeAudioSegment(buf, { dir, prefix: 'elevenlabs', sampleRate: 44100 })
-      }))
+        return Buffer.concat(chunks)
+      }
+
+      return synthesizeWithCache({
+        texts,
+        workDir: options?.workDir ?? os.tmpdir(),
+        cache: config.cacheDir ? { dir: config.cacheDir } : undefined,
+        fingerprintFor: (text) => [
+          'elevenlabs', text, voice, model, languageCode ?? '', voiceSettingsKey,
+        ],
+        generate: (missTexts) => Promise.all(missTexts.map(generateOne)),
+        prefix: 'elevenlabs',
+        format: { sampleRate: 44100, channels: 1, codec: 'mp3' },
+      })
     },
 
     async isAvailable(): Promise<boolean> {

--- a/src/voiceover/providers/openai.ts
+++ b/src/voiceover/providers/openai.ts
@@ -1,6 +1,6 @@
+import * as os from 'node:os'
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
-import { resolveWorkDir } from './util/resolveWorkDir.js'
-import { writeAudioSegment } from './util/writeAudioSegment.js'
+import { synthesizeWithCache } from './util/audio-cache.js'
 
 export interface OpenAIProviderConfig {
   apiKey?: string
@@ -14,6 +14,13 @@ export interface OpenAIProviderConfig {
   speed?: number
   /** Free-form style instructions (GPT-4o-mini-tts family). */
   instructions?: string
+  /**
+   * Directory for disk caching of synthesized audio. When set, the provider
+   * skips API calls for `(text, voice, model, speed, instructions)` tuples
+   * it has already synthesized. Omit to disable disk caching (intra-batch
+   * dedup still applies).
+   */
+  cacheDir?: string
 }
 
 const DEFAULT_VOICE = 'nova'
@@ -55,20 +62,31 @@ export function OpenAIProvider(config: OpenAIProviderConfig = {}): TtsProvider {
 
     async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
       const openai = await getClient()
-      const dir = resolveWorkDir(options?.workDir)
-      return Promise.all(texts.map(async (text) => {
+      const model = options?.model ?? defaults.model
+      const voice = options?.voice ?? defaults.voice
+      const speed = options?.speed ?? defaults.speed
+      const instructions = defaults.instructions
+
+      async function generateOne(text: string): Promise<Buffer> {
         const params: Record<string, unknown> = {
-          model: options?.model ?? defaults.model,
-          voice: options?.voice ?? defaults.voice,
-          speed: options?.speed ?? defaults.speed,
-          input: text,
-          response_format: 'mp3',
+          model, voice, speed, input: text, response_format: 'mp3',
         }
-        if (defaults.instructions) params.instructions = defaults.instructions
+        if (instructions) params.instructions = instructions
         const response = await openai.audio.speech.create(params)
-        const buf = Buffer.from(await response.arrayBuffer())
-        return writeAudioSegment(buf, { dir, prefix: 'openai', sampleRate: 24000 })
-      }))
+        return Buffer.from(await response.arrayBuffer())
+      }
+
+      return synthesizeWithCache({
+        texts,
+        workDir: options?.workDir ?? os.tmpdir(),
+        cache: config.cacheDir ? { dir: config.cacheDir } : undefined,
+        fingerprintFor: (text) => [
+          'openai', text, voice, model, speed, instructions ?? '',
+        ],
+        generate: (missTexts) => Promise.all(missTexts.map(generateOne)),
+        prefix: 'openai',
+        format: { sampleRate: 24000, channels: 1, codec: 'mp3' },
+      })
     },
 
     async isAvailable(): Promise<boolean> {

--- a/src/voiceover/providers/polly.ts
+++ b/src/voiceover/providers/polly.ts
@@ -1,6 +1,6 @@
+import * as os from 'node:os'
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
-import { resolveWorkDir } from './util/resolveWorkDir.js'
-import { writeAudioSegment } from './util/writeAudioSegment.js'
+import { synthesizeWithCache } from './util/audio-cache.js'
 
 export interface PollyProviderConfig {
   region?: string
@@ -15,6 +15,13 @@ export interface PollyProviderConfig {
   /** BCP-47 language code. */
   languageCode?: string
   textType?: 'text' | 'ssml'
+  /**
+   * Directory for disk caching of synthesized audio. When set, the provider
+   * skips API calls for `(text, voice, engine, sampleRate, languageCode,
+   * textType)` tuples it has already synthesized. Omit to disable disk
+   * caching (intra-batch dedup still applies).
+   */
+  cacheDir?: string
 }
 
 const DEFAULT_VOICE = 'Joanna'
@@ -80,33 +87,41 @@ export function PollyProvider(config: PollyProviderConfig = {}): TtsProvider {
     async synthesize(texts: string[], options?: TtsOptions): Promise<AudioSegment[]> {
       const polly = await getClient()
       const Cmd = SynthesizeSpeechCommand!
-      const dir = resolveWorkDir(options?.workDir)
+      const voice = options?.voice ?? defaults.voice
+      const languageCode = options?.languageCode ?? defaults.languageCode
+      const engine = defaults.engine!
+      const sampleRate = defaults.sampleRate!
+      const textType = defaults.textType
 
-      return Promise.all(texts.map(async (text) => {
-        const voice = options?.voice ?? defaults.voice
-        const languageCode = options?.languageCode ?? defaults.languageCode
+      async function generateOne(text: string): Promise<Buffer> {
         const input: Record<string, unknown> = {
           Text: text,
           OutputFormat: 'mp3',
           VoiceId: voice,
-          Engine: defaults.engine,
-          SampleRate: defaults.sampleRate,
-          TextType: defaults.textType,
+          Engine: engine,
+          SampleRate: sampleRate,
+          TextType: textType,
         }
         if (languageCode) input.LanguageCode = languageCode
-
         const command = new Cmd(input)
         const response = await polly.send(command)
         if (!response.AudioStream) {
           throw new Error('Amazon Polly returned no audio stream')
         }
-        const buf = Buffer.from(await response.AudioStream.transformToByteArray())
-        return writeAudioSegment(buf, {
-          dir,
-          prefix: 'polly',
-          sampleRate: Number(defaults.sampleRate),
-        })
-      }))
+        return Buffer.from(await response.AudioStream.transformToByteArray())
+      }
+
+      return synthesizeWithCache({
+        texts,
+        workDir: options?.workDir ?? os.tmpdir(),
+        cache: config.cacheDir ? { dir: config.cacheDir } : undefined,
+        fingerprintFor: (text) => [
+          'polly', text, voice, engine, sampleRate, languageCode ?? '', textType,
+        ],
+        generate: (missTexts) => Promise.all(missTexts.map(generateOne)),
+        prefix: 'polly',
+        format: { sampleRate: Number(sampleRate), channels: 1, codec: 'mp3' },
+      })
     },
 
     async isAvailable(): Promise<boolean> {

--- a/src/voiceover/providers/util/audio-cache.ts
+++ b/src/voiceover/providers/util/audio-cache.ts
@@ -1,0 +1,214 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import type { AudioSegment } from '../../../types/voiceover.js'
+import { hashValues } from './hash.js'
+
+/**
+ * Disk cache for synthesized TTS audio.
+ *
+ * Cache key: SHA-256 over a provider-supplied fingerprint that captures every
+ * input that influences the generated audio (text, voice, model, language,
+ * provider-specific settings). The fingerprint MUST include the provider name
+ * so caches from different providers don't collide in a shared directory.
+ *
+ * Cache layout: `<dir>/<hash>.<ext>`
+ */
+export interface AudioCacheConfig {
+  /** Directory to store cached audio files. Created on demand. */
+  dir: string
+}
+
+/**
+ * One entry in the batch plan.
+ *
+ * - `hit`  → the cache had this file; `cachePath` exists and was copied to
+ *            `ephemeralPath`.
+ * - `miss` → first time we've seen this fingerprint in this batch; the caller
+ *            must produce audio for `text` and write it via {@link writeMiss}.
+ * - `dup`  → a previous entry in this batch already has the same fingerprint;
+ *            after the canonical miss is written, `ephemeralPath` gets filled
+ *            with a copy of the canonical's output.
+ */
+export interface BatchEntry {
+  readonly index: number
+  readonly text: string
+  readonly hash: string
+  readonly cachePath: string | null
+  /** Final on-disk path for this entry (always inside the caller's workDir). */
+  readonly ephemeralPath: string
+  readonly kind: 'hit' | 'miss' | 'dup'
+  /** For 'dup', the index of the canonical miss entry. */
+  readonly canonicalIndex?: number
+}
+
+export interface BatchPlan {
+  readonly entries: ReadonlyArray<BatchEntry>
+  readonly missIndices: ReadonlyArray<number>
+  readonly missTexts: ReadonlyArray<string>
+}
+
+interface PlanInput {
+  texts: ReadonlyArray<string>
+  workDir: string
+  cache: AudioCacheConfig | undefined
+  fingerprintFor: (text: string) => ReadonlyArray<string | number | boolean>
+  prefix: string
+  ext: string
+}
+
+/**
+ * Partition `texts` into cache hits, fresh misses, and intra-batch duplicates.
+ *
+ * Side effects: ensures the cache directory exists (when caching) and copies
+ * each cache hit into the caller's `workDir` so the resulting paths are
+ * uniformly inside the caller's workspace (safe to rename/move).
+ */
+export function planBatch(input: PlanInput): BatchPlan {
+  const { texts, workDir, cache, fingerprintFor, prefix, ext } = input
+  if (cache) fs.mkdirSync(cache.dir, { recursive: true })
+  fs.mkdirSync(workDir, { recursive: true })
+
+  const entries: BatchEntry[] = []
+  const missIndices: number[] = []
+  const missTexts: string[] = []
+  const canonicalByHash = new Map<string, number>()
+
+  for (let i = 0; i < texts.length; i++) {
+    const text = texts[i]!
+    const hash = hashValues(fingerprintFor(text))
+    const cachePath = cache ? path.join(cache.dir, `${hash}.${ext}`) : null
+    const ephemeralPath = path.join(workDir, `${prefix}-${hash}-${i}.${ext}`)
+
+    if (cachePath && fs.existsSync(cachePath)) {
+      fs.copyFileSync(cachePath, ephemeralPath)
+      entries.push({ index: i, text, hash, cachePath, ephemeralPath, kind: 'hit' })
+      continue
+    }
+
+    const canonicalIndex = canonicalByHash.get(hash)
+    if (canonicalIndex !== undefined) {
+      entries.push({
+        index: i, text, hash, cachePath, ephemeralPath,
+        kind: 'dup', canonicalIndex,
+      })
+      continue
+    }
+
+    canonicalByHash.set(hash, i)
+    missIndices.push(i)
+    missTexts.push(text)
+    entries.push({ index: i, text, hash, cachePath, ephemeralPath, kind: 'miss' })
+  }
+
+  return { entries, missIndices, missTexts }
+}
+
+/**
+ * After the caller has produced audio for a miss, persist it:
+ *  - if a cachePath is set, write to cache first, then copy to ephemeralPath
+ *    (so subsequent EXDEV-safe renames in the caller can't destroy the cache)
+ *  - otherwise write directly to ephemeralPath.
+ */
+export function writeMiss(entry: BatchEntry, data: Buffer): void {
+  if (entry.kind !== 'miss') {
+    throw new Error(`writeMiss called on a '${entry.kind}' entry (index ${entry.index})`)
+  }
+  if (entry.cachePath) {
+    fs.mkdirSync(path.dirname(entry.cachePath), { recursive: true })
+    fs.writeFileSync(entry.cachePath, data)
+    fs.copyFileSync(entry.cachePath, entry.ephemeralPath)
+  } else {
+    fs.writeFileSync(entry.ephemeralPath, data)
+  }
+}
+
+/**
+ * After all misses have been written, copy each duplicate's ephemeralPath
+ * from its canonical sibling. Each duplicate gets its own file so callers can
+ * safely rename or move every path independently.
+ */
+export function fillDuplicates(plan: BatchPlan): void {
+  const ephemeralByIndex = new Map<number, string>()
+  for (const e of plan.entries) ephemeralByIndex.set(e.index, e.ephemeralPath)
+
+  for (const e of plan.entries) {
+    if (e.kind !== 'dup') continue
+    const src = ephemeralByIndex.get(e.canonicalIndex!)
+    if (!src) {
+      throw new Error(`duplicate ${e.index} references missing canonical ${e.canonicalIndex}`)
+    }
+    fs.copyFileSync(src, e.ephemeralPath)
+  }
+}
+
+export interface SynthesizeWithCacheOptions {
+  texts: ReadonlyArray<string>
+  workDir: string
+  /** When undefined, the helper still does intra-batch dedup but no disk caching. */
+  cache?: AudioCacheConfig
+  /**
+   * Per-text fingerprint. MUST include the provider name plus every input that
+   * influences the audio (voice, model, language, settings, speed, etc.).
+   * Anything left out causes silent cache-hit-but-wrong-audio bugs.
+   */
+  fingerprintFor: (text: string) => ReadonlyArray<string | number | boolean>
+  /**
+   * Generate audio for the miss texts (in order). The helper writes the
+   * returned buffers to disk and into the cache.
+   */
+  generate: (missTexts: ReadonlyArray<string>) => Promise<ReadonlyArray<Buffer>>
+  /** Filename prefix for ephemeral files in workDir. */
+  prefix: string
+  /** File extension + AudioSegment.format.codec. Default: 'mp3'. */
+  ext?: string
+  /** AudioSegment.format echoed onto every returned segment. */
+  format: AudioSegment['format']
+}
+
+/**
+ * High-level synthesis helper: handles cache lookup, fresh generation,
+ * cache write, and intra-batch dedup. Returns one AudioSegment per input.
+ */
+export async function synthesizeWithCache(
+  opts: SynthesizeWithCacheOptions,
+): Promise<AudioSegment[]> {
+  const ext = opts.ext ?? 'mp3'
+  const plan = planBatch({
+    texts: opts.texts,
+    workDir: opts.workDir,
+    cache: opts.cache,
+    fingerprintFor: opts.fingerprintFor,
+    prefix: opts.prefix,
+    ext,
+  })
+
+  if (plan.missIndices.length > 0) {
+    const buffers = await opts.generate(plan.missTexts)
+    if (buffers.length !== plan.missTexts.length) {
+      throw new Error(
+        `generate() returned ${buffers.length} buffers for ${plan.missTexts.length} miss texts`,
+      )
+    }
+    for (let k = 0; k < plan.missIndices.length; k++) {
+      const entry = plan.entries[plan.missIndices[k]!]!
+      writeMiss(entry, buffers[k]!)
+    }
+  }
+
+  fillDuplicates(plan)
+
+  return plan.entries.map((e) => ({
+    path: e.ephemeralPath,
+    durationMs: 0,
+    format: opts.format,
+  }))
+}
+
+/**
+ * Convenience: deterministic ephemeral filename for callers that bypass
+ * synthesizeWithCache but still want consistent naming.
+ */
+export function ephemeralName(prefix: string, ext = 'mp3'): string {
+  return `${prefix}-${crypto.randomUUID()}.${ext}`
+}

--- a/tests/unit/voiceover/audio-cache.test.ts
+++ b/tests/unit/voiceover/audio-cache.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { synthesizeWithCache, planBatch, writeMiss, fillDuplicates } from '../../../src/voiceover/providers/util/audio-cache'
+
+const TMP_ROOT = path.join(os.tmpdir(), `recast-audio-cache-test-${process.pid}`)
+
+beforeAll(() => fs.mkdirSync(TMP_ROOT, { recursive: true }))
+afterAll(() => fs.rmSync(TMP_ROOT, { recursive: true, force: true }))
+
+function makeWorkAndCache(label: string): { workDir: string; cacheDir: string } {
+  const root = path.join(TMP_ROOT, label)
+  const workDir = path.join(root, 'work')
+  const cacheDir = path.join(root, 'cache')
+  fs.mkdirSync(workDir, { recursive: true })
+  return { workDir, cacheDir }
+}
+
+function fakeAudio(text: string): Buffer {
+  return Buffer.from(`audio:${text}`)
+}
+
+describe('synthesizeWithCache', () => {
+  let calls: number
+  let lastTexts: ReadonlyArray<string>
+
+  beforeEach(() => {
+    calls = 0
+    lastTexts = []
+  })
+
+  const fingerprintFor = (text: string) => ['testprov', text, 'voice-a', 'model-a']
+  const format = { sampleRate: 24000, channels: 1 as const, codec: 'mp3' }
+
+  async function generate(texts: ReadonlyArray<string>): Promise<Buffer[]> {
+    calls++
+    lastTexts = texts
+    return texts.map(fakeAudio)
+  }
+
+  it('passes all texts to generate() on first call (cache empty)', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('first-call')
+
+    const result = await synthesizeWithCache({
+      texts: ['alpha', 'beta', 'gamma'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    expect(calls).toBe(1)
+    expect(lastTexts).toEqual(['alpha', 'beta', 'gamma'])
+    expect(result).toHaveLength(3)
+    for (const seg of result) {
+      expect(fs.existsSync(seg.path)).toBe(true)
+      expect(seg.format).toEqual(format)
+    }
+    // Cache files should now exist
+    expect(fs.readdirSync(cacheDir).length).toBe(3)
+  })
+
+  it('serves all from disk cache on a second identical call (zero generate invocations)', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('second-call')
+
+    await synthesizeWithCache({
+      texts: ['alpha', 'beta'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    calls = 0
+    lastTexts = []
+    const result = await synthesizeWithCache({
+      texts: ['alpha', 'beta'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    expect(calls).toBe(0)
+    expect(result).toHaveLength(2)
+    for (const seg of result) {
+      expect(fs.existsSync(seg.path)).toBe(true)
+      expect(fs.readFileSync(seg.path).toString().startsWith('audio:')).toBe(true)
+    }
+  })
+
+  it('only calls generate() with the texts that miss the cache', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('partial-hit')
+
+    await synthesizeWithCache({
+      texts: ['alpha'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    calls = 0
+    lastTexts = []
+    await synthesizeWithCache({
+      texts: ['alpha', 'beta', 'gamma'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    expect(calls).toBe(1)
+    expect(lastTexts).toEqual(['beta', 'gamma'])
+  })
+
+  it('dedups identical texts within a batch (one generate call per unique text)', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('intra-batch-dedup')
+
+    const result = await synthesizeWithCache({
+      texts: ['x', 'y', 'x', 'y', 'x'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    expect(calls).toBe(1)
+    expect(lastTexts).toEqual(['x', 'y']) // only unique misses
+    expect(result).toHaveLength(5)
+    // Each duplicate gets its own ephemeral file
+    const paths = result.map((r) => r.path)
+    expect(new Set(paths).size).toBe(5)
+    // Content must match per text
+    expect(fs.readFileSync(result[0].path).toString()).toBe('audio:x')
+    expect(fs.readFileSync(result[2].path).toString()).toBe('audio:x')
+    expect(fs.readFileSync(result[4].path).toString()).toBe('audio:x')
+    expect(fs.readFileSync(result[1].path).toString()).toBe('audio:y')
+    expect(fs.readFileSync(result[3].path).toString()).toBe('audio:y')
+  })
+
+  it('does intra-batch dedup even when disk cache is disabled', async () => {
+    const { workDir } = makeWorkAndCache('no-cache-dedup')
+
+    const result = await synthesizeWithCache({
+      texts: ['x', 'x', 'y'],
+      workDir,
+      cache: undefined,
+      fingerprintFor,
+      generate,
+      prefix: 'testprov',
+      format,
+    })
+
+    expect(calls).toBe(1)
+    expect(lastTexts).toEqual(['x', 'y'])
+    expect(result).toHaveLength(3)
+    expect(fs.readFileSync(result[0].path).toString()).toBe('audio:x')
+    expect(fs.readFileSync(result[1].path).toString()).toBe('audio:x')
+    expect(fs.readFileSync(result[2].path).toString()).toBe('audio:y')
+  })
+
+  it('different fingerprints (e.g. different voices) are independent cache entries', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('fingerprint-sensitivity')
+
+    // First call: voice-a
+    await synthesizeWithCache({
+      texts: ['hello'],
+      workDir, cache: { dir: cacheDir },
+      fingerprintFor: (t) => ['testprov', t, 'voice-a'],
+      generate, prefix: 'testprov', format,
+    })
+
+    calls = 0
+    // Second call: voice-b — must miss cache, call generate
+    await synthesizeWithCache({
+      texts: ['hello'],
+      workDir, cache: { dir: cacheDir },
+      fingerprintFor: (t) => ['testprov', t, 'voice-b'],
+      generate, prefix: 'testprov', format,
+    })
+
+    expect(calls).toBe(1)
+    expect(fs.readdirSync(cacheDir).length).toBe(2) // two different hashes
+  })
+
+  it('throws when generate() returns fewer buffers than miss texts', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('length-mismatch')
+
+    const wrongGenerate = async (texts: ReadonlyArray<string>) =>
+      [Buffer.from('x')] // always one regardless of input
+
+    await expect(
+      synthesizeWithCache({
+        texts: ['a', 'b', 'c'],
+        workDir,
+        cache: { dir: cacheDir },
+        fingerprintFor,
+        generate: wrongGenerate,
+        prefix: 'testprov',
+        format,
+      }),
+    ).rejects.toThrow(/returned 1 buffers for 3 miss texts/)
+  })
+
+  it('cache hit content equals the originally generated buffer', async () => {
+    const { workDir, cacheDir } = makeWorkAndCache('content-fidelity')
+
+    await synthesizeWithCache({
+      texts: ['hello'],
+      workDir, cache: { dir: cacheDir },
+      fingerprintFor, generate, prefix: 'testprov', format,
+    })
+
+    const result = await synthesizeWithCache({
+      texts: ['hello'],
+      workDir, cache: { dir: cacheDir },
+      fingerprintFor, generate, prefix: 'testprov', format,
+    })
+
+    expect(fs.readFileSync(result[0].path)).toEqual(fakeAudio('hello'))
+  })
+})
+
+describe('planBatch primitive', () => {
+  const fingerprintFor = (text: string) => ['testprov', text]
+
+  it('classifies entries as hit / miss / dup correctly', () => {
+    const { workDir, cacheDir } = makeWorkAndCache('plan-classify')
+    fs.mkdirSync(cacheDir, { recursive: true })
+    // Pre-seed cache with one hash so 'cached' is a hit
+    const seedPlan = planBatch({
+      texts: ['cached'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor, prefix: 'p', ext: 'mp3',
+    })
+    writeMiss(seedPlan.entries[0]!, Buffer.from('PRE'))
+
+    const plan = planBatch({
+      texts: ['cached', 'fresh', 'fresh'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor, prefix: 'p', ext: 'mp3',
+    })
+
+    expect(plan.entries.map((e) => e.kind)).toEqual(['hit', 'miss', 'dup'])
+    expect(plan.missIndices).toEqual([1])
+    expect(plan.missTexts).toEqual(['fresh'])
+    expect(plan.entries[2]!.canonicalIndex).toBe(1)
+  })
+
+  it('fillDuplicates copies canonical to dup paths', () => {
+    const { workDir, cacheDir } = makeWorkAndCache('plan-dup-fill')
+    fs.mkdirSync(cacheDir, { recursive: true })
+
+    const plan = planBatch({
+      texts: ['same', 'same'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor, prefix: 'p', ext: 'mp3',
+    })
+
+    writeMiss(plan.entries[0]!, Buffer.from('CANON'))
+    fillDuplicates(plan)
+
+    expect(fs.readFileSync(plan.entries[1]!.ephemeralPath).toString()).toBe('CANON')
+    // Distinct files — caller can rename one without affecting the other
+    expect(plan.entries[0]!.ephemeralPath).not.toBe(plan.entries[1]!.ephemeralPath)
+  })
+
+  it('writeMiss on a non-miss entry throws', () => {
+    const { workDir, cacheDir } = makeWorkAndCache('writeMiss-guard')
+    fs.mkdirSync(cacheDir, { recursive: true })
+
+    const seed = planBatch({
+      texts: ['x'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor, prefix: 'p', ext: 'mp3',
+    })
+    writeMiss(seed.entries[0]!, Buffer.from('SEEDED'))
+
+    const plan = planBatch({
+      texts: ['x', 'y', 'y'],
+      workDir,
+      cache: { dir: cacheDir },
+      fingerprintFor, prefix: 'p', ext: 'mp3',
+    })
+
+    // entries[0] is a hit, entries[2] is a dup — both must reject writeMiss
+    expect(() => writeMiss(plan.entries[0]!, Buffer.from('X'))).toThrow(/'hit'/)
+    expect(() => writeMiss(plan.entries[2]!, Buffer.from('Y'))).toThrow(/'dup'/)
+  })
+})

--- a/tests/unit/voiceover/providers.test.ts
+++ b/tests/unit/voiceover/providers.test.ts
@@ -99,6 +99,37 @@ describe('ElevenLabsProvider', () => {
     const args = mocks.convertMock.mock.calls[0]![1] as Record<string, unknown>
     expect(args).not.toHaveProperty('voiceSettings')
   })
+
+  it('cacheDir: second batch with same fingerprint serves from disk and does not call the API', async () => {
+    const cacheDir = path.join(TMP_ROOT, `el-cache-${Date.now()}-${Math.random()}`)
+    const p = ElevenLabsProvider({
+      apiKey: 'k', voice: 'v1', model: 'm1', languageCode: 'cs', cacheDir,
+    })
+    const workDir = path.join(TMP_ROOT, `el-work-${Date.now()}-${Math.random()}`)
+
+    await p.synthesize(['hello', 'world'], { workDir })
+    expect(mocks.convertMock).toHaveBeenCalledTimes(2)
+
+    mocks.convertMock.mockClear()
+    const result = await p.synthesize(['hello', 'world'], { workDir })
+
+    expect(mocks.convertMock).not.toHaveBeenCalled()
+    expect(result).toHaveLength(2)
+    for (const seg of result) expect(fs.existsSync(seg.path)).toBe(true)
+  })
+
+  it('cacheDir: different voice produces a separate cache entry', async () => {
+    const cacheDir = path.join(TMP_ROOT, `el-voice-${Date.now()}-${Math.random()}`)
+    const workDir = path.join(TMP_ROOT, `el-voice-w-${Date.now()}-${Math.random()}`)
+
+    const a = ElevenLabsProvider({ apiKey: 'k', voice: 'v1', cacheDir })
+    await a.synthesize(['hello'], { workDir })
+    mocks.convertMock.mockClear()
+
+    const b = ElevenLabsProvider({ apiKey: 'k', voice: 'v2', cacheDir })
+    await b.synthesize(['hello'], { workDir })
+    expect(mocks.convertMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 // --- OpenAI ---------------------------------------------------------------
@@ -144,6 +175,19 @@ describe('OpenAIProvider', () => {
     const args = mocks.openaiCreateMock.mock.calls[0]![0] as Record<string, unknown>
     expect(args).not.toHaveProperty('instructions')
   })
+
+  it('cacheDir: second batch with same fingerprint serves from disk and does not call the API', async () => {
+    const cacheDir = path.join(TMP_ROOT, `oa-cache-${Date.now()}-${Math.random()}`)
+    const workDir = path.join(TMP_ROOT, `oa-work-${Date.now()}-${Math.random()}`)
+    const p = OpenAIProvider({ apiKey: 'k', voice: 'nova', model: 'tts-1', cacheDir })
+
+    await p.synthesize(['hi', 'there'], { workDir })
+    expect(mocks.openaiCreateMock).toHaveBeenCalledTimes(2)
+
+    mocks.openaiCreateMock.mockClear()
+    await p.synthesize(['hi', 'there'], { workDir })
+    expect(mocks.openaiCreateMock).not.toHaveBeenCalled()
+  })
 })
 
 // --- Polly ---------------------------------------------------------------
@@ -187,5 +231,26 @@ describe('PollyProvider', () => {
     mocks.pollySendMock.mockResolvedValueOnce({})
     const p = PollyProvider({ region: 'us-east-1', accessKeyId: 'a', secretAccessKey: 's' })
     await expect(p.synthesize(['x'], { workDir: TMP_ROOT })).rejects.toThrow(/no audio stream/i)
+  })
+
+  it('cacheDir: second batch with same fingerprint serves from disk and does not call the API', async () => {
+    const cacheDir = path.join(TMP_ROOT, `polly-cache-${Date.now()}-${Math.random()}`)
+    const workDir = path.join(TMP_ROOT, `polly-work-${Date.now()}-${Math.random()}`)
+    const p = PollyProvider({
+      region: 'us-east-1', accessKeyId: 'a', secretAccessKey: 's',
+      voice: 'Joanna', cacheDir,
+    })
+
+    await p.synthesize(['hi', 'there'], { workDir })
+    expect(mocks.pollySendMock).toHaveBeenCalledTimes(2)
+
+    mocks.pollySendMock.mockClear()
+    mocks.pollyCommandCalls.length = 0
+    mocks.pollySendMock.mockResolvedValue({
+      AudioStream: { transformToByteArray: async () => new Uint8Array([1, 2, 3]) },
+    })
+
+    await p.synthesize(['hi', 'there'], { workDir })
+    expect(mocks.pollySendMock).not.toHaveBeenCalled()
   })
 })

--- a/website/components/landing/hero.tsx
+++ b/website/components/landing/hero.tsx
@@ -135,7 +135,7 @@ export function Hero() {
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
             </span>
-            <span className="truncate">v0.17.0 — local TTS with Qwen3-TTS voice clone &amp; design</span>
+            <span className="truncate">v0.18.0 — disk cache for ElevenLabs / OpenAI / Polly providers</span>
           </div>
         </BlurFade>
 

--- a/website/content/docs/providers/elevenlabs.mdx
+++ b/website/content/docs/providers/elevenlabs.mdx
@@ -89,3 +89,24 @@ npx playwright-recast -i ./traces --srt narration.srt --provider elevenlabs --vo
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ELEVENLABS_API_KEY` | Yes (unless `apiKey` is set) | Your ElevenLabs API key |
+
+## Disk caching
+
+Set `cacheDir` to skip API calls for text the provider has already synthesized
+in a previous run. The cache key is a SHA-256 over `(text, voice, model,
+languageCode, voiceSettings)` so a change to any of these inputs invalidates
+the entry.
+
+```typescript
+ElevenLabsProvider({
+  voice: 'onwK4e9ZLuTAKqWW03F9',
+  model: 'eleven_multilingual_v2',
+  languageCode: 'cs',
+  cacheDir: './.recast-cache/elevenlabs',
+})
+```
+
+Cache layout: `<cacheDir>/<hash>.mp3` (flat). Safe to commit to git or share
+across machines — files are content-addressable. Omit `cacheDir` to disable
+disk caching; intra-batch dedup (re-using identical narration within a single
+render) still applies.

--- a/website/content/docs/providers/openai.mdx
+++ b/website/content/docs/providers/openai.mdx
@@ -82,3 +82,22 @@ npx playwright-recast -i ./traces --srt narration.srt --provider openai --voice 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `OPENAI_API_KEY` | Yes (unless `apiKey` is set) | Your OpenAI API key |
+
+## Disk caching
+
+Set `cacheDir` to skip API calls for text the provider has already synthesized
+in a previous run. The cache key is a SHA-256 over `(text, voice, model,
+speed, instructions)` so a change to any of these inputs invalidates the
+entry.
+
+```typescript
+OpenAIProvider({
+  voice: 'nova',
+  model: 'gpt-4o-mini-tts',
+  speed: 1.1,
+  cacheDir: './.recast-cache/openai',
+})
+```
+
+Cache layout: `<cacheDir>/<hash>.mp3` (flat). Omit `cacheDir` to disable disk
+caching; intra-batch dedup still applies.

--- a/website/content/docs/providers/polly.mdx
+++ b/website/content/docs/providers/polly.mdx
@@ -104,3 +104,21 @@ npx playwright-recast -i ./traces --srt narration.srt --provider polly --voice M
 | `AWS_SESSION_TOKEN` | Optional | Required when using temporary STS credentials. |
 | `AWS_PROFILE` | Optional | Use a specific profile from `~/.aws/credentials`. |
 | `RECAST_POLLY_ENGINE` | Optional | MCP default engine. Defaults to `neural`. |
+
+## Disk caching
+
+Set `cacheDir` to skip Polly API calls for text the provider has already
+synthesized in a previous run. The cache key is a SHA-256 over `(text, voice,
+engine, sampleRate, languageCode, textType)`.
+
+```typescript
+PollyProvider({
+  voice: 'Joanna',
+  engine: 'neural',
+  languageCode: 'en-US',
+  cacheDir: './.recast-cache/polly',
+})
+```
+
+Cache layout: `<cacheDir>/<hash>.mp3` (flat). Omit `cacheDir` to disable disk
+caching; intra-batch dedup still applies.


### PR DESCRIPTION
## Summary

Adds opt-in `cacheDir` on `ElevenLabsProvider`, `OpenAIProvider`, and `PollyProvider`. When set, re-renders skip the API call for `(text, voice, model, language, settings)` tuples already synthesized. Inspired by the cache already in `QwenTtsProvider` ([#9](https://github.com/ThePatriczek/playwright-recast/pull/9)) — same hash-based pattern, generalized.

## Why

ElevenLabs and OpenAI charge per character. The most common workflow with this library is iterative — render once, watch, tweak a subtitle, re-render. Without a cache every re-render re-synthesizes every line. With `cacheDir`, only the lines that actually changed hit the API.

```ts
.voiceover(ElevenLabsProvider({
  voice: 'daniel',
  cacheDir: './.recast-cache/elevenlabs',   // ← opt-in
}))
```

## Implementation

New util: `src/voiceover/providers/util/audio-cache.ts`

- **`synthesizeWithCache()`** — high-level helper. One call covers cache lookup, fresh generation, cache write, and intra-batch dedup.
- **`planBatch` / `writeMiss` / `fillDuplicates`** — low-level primitives for providers with custom write paths (e.g. WAV→MP3 conversion, like Qwen).

ElevenLabs / OpenAI / Polly are migrated to `synthesizeWithCache`. Per-provider boilerplate drops to a single `generateOne(text)` function. The fingerprint per provider includes the provider name plus every audio-affecting setting, so users can safely point multiple providers at the same `cacheDir` without collisions.

**Intra-batch dedup applies whether or not disk cache is enabled** — re-using identical narration in one render synthesizes once and copies for siblings.

## Qwen

Not migrated to share the helper in this PR. Its `planSynthesis` covers the same shape but the miss-write path runs through `ffmpeg` (WAV → MP3), not a plain buffer write. Worth folding together if Qwen ever drops the WAV intermediate.

## Tests

- `tests/unit/voiceover/audio-cache.test.ts` (11): hits/misses/dups, partial-hit batches, fingerprint sensitivity (different voice = different cache entry), length-mismatch guard, content fidelity, low-level primitives.
- `tests/unit/voiceover/providers.test.ts` (+4): per-provider cache hit on second batch, voice-change invalidation.
- Full suite: **410 passed** (+15).

## Docs

- `README.md` — `cacheDir` in each provider example
- `website/content/docs/providers/{elevenlabs,openai,polly}.mdx` — new "Disk caching" section per provider with fingerprint composition
- Hero badge → v0.18.0
- `CHANGELOG.md` — 0.18.0 entry

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (410 passed)
- [ ] CI green on this PR
- [ ] Manual smoke: render the demo twice, verify second run skips API calls (visible in EL/OpenAI dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)