### PR TITLE
docs(qwen): drop uv/conda alternatives, rename venv to playwright-recast

### DIFF
--- a/.claude/playwright-recast/skills/recast-guide/SKILL.md
+++ b/.claude/playwright-recast/skills/recast-guide/SKILL.md
@@ -147,8 +147,8 @@ QwenTtsProvider({
 Setup — PyTorch + flash-attn is ~5–8 GB, so recommend **one shared venv reused across projects** pointed at via `pythonBin`:
 
 ```bash
-python3 -m venv ~/.venvs/qwen-tts
-~/.venvs/qwen-tts/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+python3 -m venv ~/.venvs/playwright-recast
+~/.venvs/playwright-recast/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
 ```
 
 ```typescript
@@ -156,11 +156,11 @@ QwenTtsProvider({
   mode: 'clone',
   voiceSample: './ref.wav',
   refText: 'Sample transcript.',
-  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+  pythonBin: `${process.env.HOME}/.venvs/playwright-recast/bin/python3`,
 })
 ```
 
-Alternatives: `uv venv` + `uv pip install` (hardlinks from a global wheel store — per-project `.venv` becomes nearly free); or a per-project `.venv` for full isolation (costs ~5–8 GB/project without `uv`); or a conda env. Whichever you pick, pass the venv's `bin/python3` (absolute path) as `pythonBin` so no shell activation is needed.
+Pass the venv's `bin/python3` as an absolute path so no shell activation is needed.
 
 Needs a CUDA GPU (~4–8 GB VRAM) and `HF_TOKEN` if the chosen weights are gated. Failures surface as `QwenSidecarError` with a `stage` field (`init` / `design` / `clone`).
 

--- a/README.md
+++ b/README.md
@@ -398,8 +398,8 @@ flash-attn), so the recommended setup is **one shared venv reused across
 projects**, pointed at via `pythonBin`:
 
 ```bash
-python3 -m venv ~/.venvs/qwen-tts
-~/.venvs/qwen-tts/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+python3 -m venv ~/.venvs/playwright-recast
+~/.venvs/playwright-recast/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
 ```
 
 ```typescript
@@ -407,18 +407,12 @@ python3 -m venv ~/.venvs/qwen-tts
   mode: 'clone',
   voiceSample: './my-voice.wav',
   refText: 'Welcome! In this screencast we will walk through the key concepts.',
-  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+  pythonBin: `${process.env.HOME}/.venvs/playwright-recast/bin/python3`,
 }))
 ```
 
 Absolute `pythonBin` means no shell activation required — works in CI,
 cron jobs, and IDE runners alike.
-
-**Alternatives:**
-
-- **`uv`** (Astral): `uv venv ~/.venvs/qwen-tts && uv pip install -p ~/.venvs/qwen-tts/bin/python -r .../requirements.txt`. `uv` hardlinks from a global wheel store, so even a per-project `.venv` is nearly free on disk.
-- **Per-project `.venv`**: `python3 -m venv .venv` and `pythonBin: '.venv/bin/python3'`. Cleanest isolation; costs ~5–8 GB per project unless you're using `uv`.
-- **Conda**: works the same way — point `pythonBin` at the env's interpreter.
 
 Requires a CUDA-capable GPU (~4–8 GB VRAM depending on model). `HF_TOKEN` in
 the environment if the chosen weights are gated.

--- a/src/voiceover/providers/qwen-sidecar/README.md
+++ b/src/voiceover/providers/qwen-sidecar/README.md
@@ -17,8 +17,8 @@ The deps (PyTorch + flash-attn + Qwen) are ~5–8 GB. Recommended pattern is
 **one shared venv reused across projects**:
 
 ```bash
-python3 -m venv ~/.venvs/qwen-tts
-~/.venvs/qwen-tts/bin/pip install -r requirements.txt
+python3 -m venv ~/.venvs/playwright-recast
+~/.venvs/playwright-recast/bin/pip install -r requirements.txt
 ```
 
 When invoked from `QwenTtsProvider`, point `pythonBin` at it — absolute
@@ -29,15 +29,9 @@ QwenTtsProvider({
   mode: 'clone',
   voiceSample: './ref.wav',
   refText: 'Sample transcript.',
-  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+  pythonBin: `${process.env.HOME}/.venvs/playwright-recast/bin/python3`,
 })
 ```
-
-Alternatives:
-
-- **`uv`** — `uv venv ~/.venvs/qwen-tts && uv pip install -p ~/.venvs/qwen-tts/bin/python -r requirements.txt`. Hardlinks from a global store, so even per-project venvs are nearly free on disk.
-- **Per-project `.venv`** — `python3 -m venv .venv` for full isolation; costs ~5–8 GB/project without `uv`.
-- **Conda** — same idea; pass the env's `bin/python3` to `pythonBin`.
 
 `flash-attn` requires CUDA toolchain at build time. If the precompiled wheel
 is unavailable for your environment, follow the install instructions at

--- a/website/content/docs/providers/qwen.mdx
+++ b/website/content/docs/providers/qwen.mdx
@@ -22,11 +22,11 @@ No npm peer dependency is required — the provider talks to the sidecar over st
 
 The sidecar's stack (PyTorch + `flash-attn` + Qwen) is **~5–8 GB on disk**, so where you install it matters. pip caches *downloads* in `~/.cache/pip`, but *installs* are copied into each venv's `site-packages` — so a per-project venv with PyTorch costs ~5–8 GB **per project**.
 
-### Recommended: one shared venv reused across projects
+### Shared venv reused across projects
 
 ```bash
-python3 -m venv ~/.venvs/qwen-tts
-~/.venvs/qwen-tts/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
+python3 -m venv ~/.venvs/playwright-recast
+~/.venvs/playwright-recast/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
 ```
 
 ```typescript
@@ -34,35 +34,11 @@ QwenTtsProvider({
   mode: 'clone',
   voiceSample: './my-voice.wav',
   refText: 'Welcome! In this screencast we will walk through the key concepts.',
-  pythonBin: `${process.env.HOME}/.venvs/qwen-tts/bin/python3`,
+  pythonBin: `${process.env.HOME}/.venvs/playwright-recast/bin/python3`,
 })
 ```
 
 Absolute `pythonBin` works regardless of shell activation — useful for CI, cron, and IDE runners.
-
-### Alternative: `uv` (most disk-efficient)
-
-[`uv`](https://github.com/astral-sh/uv) hardlinks every venv from a global wheel store, so per-project `.venv`s cost almost nothing on disk:
-
-```bash
-uv venv ~/.venvs/qwen-tts
-uv pip install --python ~/.venvs/qwen-tts/bin/python -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
-```
-
-If you've got `uv` installed, even a per-project `.venv` is reasonable — the hardlinks deduplicate PyTorch automatically.
-
-### Alternative: per-project `.venv` (full isolation)
-
-```bash
-python3 -m venv .venv
-.venv/bin/pip install -r node_modules/playwright-recast/dist/voiceover/providers/qwen-sidecar/requirements.txt
-```
-
-Then `pythonBin: '.venv/bin/python3'`. Cleanest isolation; pay ~5–8 GB per project unless paired with `uv`.
-
-### Conda
-
-Works the same way — point `pythonBin` at the env's `bin/python3` (or `.../envs/<name>/bin/python3`).
 
 ### `flash-attn` build notes
 


### PR DESCRIPTION
The single one-shared-venv flow is what we actually recommend; the uv, per-project, and conda alternatives just added surface area. Rename ~/.venvs/qwen-tts to ~/.venvs/playwright-recast so the venv is shared across all sidecars, not just Qwen.