### PR TITLE
fix(hideSteps): drop hidden-step content from clicks, cursor, and rendered video

### DIFF
--- a/src/filter/step-filter.ts
+++ b/src/filter/step-filter.ts
@@ -3,21 +3,29 @@ import type { ParsedTrace, FilteredTrace, TraceAction, MonotonicMs } from '../ty
 /**
  * Filter out actions matching the predicate.
  * Hidden actions are removed from the action list and their time ranges are recorded.
+ * Child actions whose time falls inside a hidden range are also removed, so that
+ * downstream stages (clickEffect, cursorOverlay, subtitles) do not surface clicks
+ * or cursor motion from inside a hidden parent step like `test.step('login', ...)`.
  */
 export function filterSteps(
   trace: ParsedTrace,
   predicate: (action: TraceAction) => boolean,
 ): FilteredTrace {
   const hidden: Array<{ start: MonotonicMs; end: MonotonicMs }> = []
-  const visible: TraceAction[] = []
+  const remaining: TraceAction[] = []
 
   for (const action of trace.actions) {
     if (predicate(action)) {
       hidden.push({ start: action.startTime, end: action.endTime })
     } else {
-      visible.push(action)
+      remaining.push(action)
     }
   }
+
+  const visible = remaining.filter((action) => {
+    const t = action.startTime as number
+    return !hidden.some((r) => t >= (r.start as number) && t < (r.end as number))
+  })
 
   return {
     ...trace,

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process'
 import type { StageDescriptor } from './stages.js'
 import type { ParsedTrace, FilteredTrace, TraceAction } from '../types/trace.js'
 import { toMonotonic } from '../types/trace.js'
-import type { SpeedMappedTrace } from '../types/speed.js'
+import type { SpeedConfig, SpeedMappedTrace } from '../types/speed.js'
 import type { SubtitledTrace, SubtitleEntry } from '../types/subtitle.js'
 import {
   NARRATE_TITLE_PREFIX,
@@ -44,6 +44,7 @@ type PipelineState = {
   parsed?: ParsedTrace
   filtered?: FilteredTrace
   speedMapped?: SpeedMappedTrace
+  speedConfig?: SpeedConfig
   subtitled?: SubtitledTrace
   voiceovered?: VoiceoveredTrace
   sourceVideoPath?: string
@@ -301,11 +302,18 @@ export class PipelineExecutor {
         case 'hideSteps': {
           if (!state.parsed) throw new Error('hideSteps() requires parse() first')
           state.filtered = filterSteps(state.parsed, stage.predicate)
+          // If speedUp() already ran, its segments were built without the new
+          // hiddenRanges — rebuild so the renderer actually cuts the hidden
+          // portions out of the video.
+          if (state.speedMapped && state.speedConfig) {
+            state.speedMapped = processSpeed(state.filtered, state.speedConfig)
+          }
           break
         }
 
         case 'speedUp': {
           if (!state.filtered) throw new Error('speedUp() requires parse() first')
+          state.speedConfig = stage.config
           state.speedMapped = processSpeed(state.filtered, stage.config)
           const segs = state.speedMapped.speedSegments
           const uniqueSpeeds = [...new Set(segs.map(s => s.speed))]
@@ -712,7 +720,9 @@ export class PipelineExecutor {
           const recFramesCursor = recPageIdCursor
             ? state.parsed.frames.filter(f => f.pageId === recPageIdCursor) : state.parsed.frames
           const recStartCursor = recFramesCursor[0]?.timestamp as number ?? 0
-          const cursorActions = state.parsed.actions.filter(a => (a.startTime as number) >= recStartCursor)
+          // Use filtered actions so cursor positions from hidden steps are dropped.
+          const cursorSourceActions = state.filtered?.actions ?? state.parsed.actions
+          const cursorActions = cursorSourceActions.filter(a => (a.startTime as number) >= recStartCursor)
 
           const keyframes = buildTrajectory({
             actions: cursorActions as Array<{ point?: { x: number; y: number }; startTime: number }>,
@@ -744,8 +754,10 @@ export class PipelineExecutor {
             ? state.parsed.frames.filter(f => f.pageId === recPageIdClick) : state.parsed.frames
           const recStartClick = recFramesClick[0]?.timestamp as number ?? 0
 
-          // Only include actions from the recording context (after recording started)
-          let clickActions = state.parsed.actions.filter(
+          // Use filtered actions so clicks inside hideSteps() ranges are dropped —
+          // otherwise they get remapped onto video time 0 (or end) and pile up.
+          const sourceActions = state.filtered?.actions ?? state.parsed.actions
+          let clickActions = sourceActions.filter(
             (a) => CLICK_METHODS.has(a.method) && a.point && (a.startTime as number) >= recStartClick,
           )
 

--- a/src/speed/speed-processor.ts
+++ b/src/speed/speed-processor.ts
@@ -200,12 +200,19 @@ export function processSpeed(
     rawSegments.push({ start: t, end: segEnd, speed })
   }
 
-  // Apply minSegmentDuration: merge short segments into neighbors
+  // Apply minSegmentDuration: merge short segments into neighbors.
+  // Only merge into the previous segment when they are adjacent — merging
+  // across a gap (a hideSteps() hidden range) would extend the previous
+  // segment over the hidden span and pull the cut content back into the
+  // rendered output.
   const merged: typeof rawSegments = []
   for (const seg of rawSegments) {
     if (merged.length > 0) {
       const last = merged[merged.length - 1]!
-      if (seg.end - seg.start < c.minSegmentDuration) {
+      if (
+        seg.end - seg.start < c.minSegmentDuration &&
+        last.end === seg.start
+      ) {
         // Merge into previous segment (use slower speed to avoid jarring)
         last.end = seg.end
         last.speed = Math.min(last.speed, seg.speed)

--- a/src/speed/time-remap.ts
+++ b/src/speed/time-remap.ts
@@ -20,7 +20,10 @@ export function computeOutputTimes(segments: SpeedSegment[]): SpeedSegment[] {
 
 /**
  * Build a function that maps original trace time to output video time.
- * Interpolates within speed segments.
+ * Interpolates within speed segments; times that fall inside a gap between
+ * segments (e.g. a hideSteps() hidden range) snap to the next segment's
+ * output start — gaps collapse to zero output duration, so the boundary
+ * shared with the previous segment's outputEnd is the right answer.
  */
 export function buildTimeRemap(segments: SpeedSegment[]): TimeRemapFn {
   return (originalTime: MonotonicMs): number => {
@@ -36,7 +39,8 @@ export function buildTimeRemap(segments: SpeedSegment[]): TimeRemapFn {
       const segStart = seg.originalStart as number
       const segEnd = seg.originalEnd as number
 
-      if (t < segStart) continue
+      // In a gap before this segment — snap forward to its start.
+      if (t < segStart) return seg.outputStart
       if (t > segEnd) continue
 
       const elapsed = t - segStart

--- a/tests/unit/filter/step-filter.test.ts
+++ b/tests/unit/filter/step-filter.test.ts
@@ -94,6 +94,60 @@ describe('filterSteps', () => {
     expect(result.hiddenRanges).toHaveLength(2)
   })
 
+  it('drops child actions whose time falls inside a hidden parent step', () => {
+    const parent: TraceAction = {
+      callId: 'parent',
+      title: 'login',
+      class: 'test.step',
+      method: 'step',
+      params: {},
+      startTime: toMonotonic(1000),
+      endTime: toMonotonic(5000),
+    }
+    const childClickA: TraceAction = {
+      callId: 'child-a',
+      title: 'click submit',
+      class: 'Locator',
+      method: 'click',
+      params: {},
+      startTime: toMonotonic(1500),
+      endTime: toMonotonic(1600),
+      parentId: 'parent',
+      point: { x: 10, y: 20, timestamp: toMonotonic(1500) },
+    }
+    const childClickB: TraceAction = {
+      callId: 'child-b',
+      title: 'click next',
+      class: 'Locator',
+      method: 'click',
+      params: {},
+      startTime: toMonotonic(2500),
+      endTime: toMonotonic(2600),
+      parentId: 'parent',
+      point: { x: 30, y: 40, timestamp: toMonotonic(2500) },
+    }
+    const visibleClick: TraceAction = {
+      callId: 'visible',
+      title: 'click after',
+      class: 'Locator',
+      method: 'click',
+      params: {},
+      startTime: toMonotonic(6000),
+      endTime: toMonotonic(6100),
+      point: { x: 50, y: 60, timestamp: toMonotonic(6000) },
+    }
+    const trace = makeTrace([parent, childClickA, childClickB, visibleClick])
+
+    const result = filterSteps(trace, (a) => a.title === 'login')
+
+    expect(result.actions).toHaveLength(1)
+    expect(result.actions[0]!.callId).toBe('visible')
+    expect(result.hiddenRanges).toEqual([
+      { start: toMonotonic(1000), end: toMonotonic(5000) },
+    ])
+    expect(result.originalActions).toHaveLength(4)
+  })
+
   it('returns unchanged trace when no actions match', () => {
     const actions = [
       makeAction('When', 'step 1', 0, 5000),

--- a/tests/unit/speed/speed-processor.test.ts
+++ b/tests/unit/speed/speed-processor.test.ts
@@ -181,6 +181,41 @@ describe('processSpeed', () => {
     }
   })
 
+  it('does not merge short segments across a hideSteps() gap', () => {
+    // Reproduces the bug where a short pre-hidden segment + a short
+    // post-hidden segment of the same speed got merged into one segment
+    // that swallowed the hidden range — causing the renderer to slice
+    // the hidden content back into the output.
+    // Trace: short navigation before hidden range, short navigation after,
+    // both 2x; the hidden gap must remain a gap in segment coverage.
+    const actions = [
+      makeAction(1300, 1400, 'goto'),
+      makeAction(15000, 15100, 'goto'),
+    ]
+    const trace: FilteredTrace = {
+      ...makeTrace(actions, [], 1000, 17000),
+      hiddenRanges: [
+        { start: toMonotonic(1500) as MonotonicMs, end: toMonotonic(14800) as MonotonicMs },
+      ],
+    }
+    const result = processSpeed(trace, {
+      duringIdle: 3.0,
+      duringUserAction: 1.0,
+      duringNavigation: 2.0,
+      minSegmentDuration: 500,
+    })
+
+    // No segment may span across the hidden range.
+    const HIDDEN_START = 1500
+    const HIDDEN_END = 14800
+    for (const seg of result.speedSegments) {
+      const s = seg.originalStart as number
+      const e = seg.originalEnd as number
+      const spansGap = s < HIDDEN_START && e > HIDDEN_END
+      expect(spansGap, `segment [${s}, ${e}] spans hidden range`).toBe(false)
+    }
+  })
+
   it('provides a working timeRemap function', () => {
     const actions = [makeAction(0, 1000, 'click')]
     const trace = makeTrace(actions, [], 0, 3000)

--- a/tests/unit/speed/time-remap.test.ts
+++ b/tests/unit/speed/time-remap.test.ts
@@ -142,5 +142,33 @@ describe('Time Remap', () => {
       // 4000 at 2x = 2000 output. Time 5000 should clamp to 2000.
       expect(remap(toMonotonic(5000))).toBe(2000)
     })
+
+    it('snaps time inside a hidden gap to the next segment boundary', () => {
+      // Simulates hideSteps() removing [1000, 5000] — segments end at 1000
+      // and resume at 5000 with the gap collapsed in output time.
+      const segments = computeOutputTimes([
+        {
+          originalStart: toMonotonic(0),
+          originalEnd: toMonotonic(1000),
+          speed: 1.0,
+          outputStart: 0,
+          outputEnd: 0,
+        },
+        {
+          originalStart: toMonotonic(5000),
+          originalEnd: toMonotonic(9000),
+          speed: 1.0,
+          outputStart: 0,
+          outputEnd: 0,
+        },
+      ])
+      const remap = buildTimeRemap(segments)
+      // 3000 falls inside the gap [1000, 5000] — should snap to second
+      // segment's outputStart (1000), not to last.outputEnd (5000).
+      expect(remap(toMonotonic(3000))).toBe(1000)
+      // Boundaries still work.
+      expect(remap(toMonotonic(5000))).toBe(1000)
+      expect(remap(toMonotonic(7000))).toBe(3000)
+    })
   })
 })


### PR DESCRIPTION
Four interacting bugs caused hidden steps to leak into the output:

- filterSteps() only removed the predicate-matched action — child clicks of a hidden test.step (e.g. `test.step('login', ...)`) survived in filtered.actions.
- clickEffect and cursorOverlay read state.parsed.actions, so they bypassed hideSteps entirely and surfaced clicks/cursor motion from inside hidden steps.
- speedUp() ran once with the hiddenRanges that existed when it was added to the pipeline, so calling .hideSteps() after .speedUp() left the speed map covering the hidden range and the renderer kept the hidden footage in.
- buildTimeRemap() returned last.outputEnd when a trace time fell in a segment gap, sending videoStartOutput to the end of the video and clamping every click to videoTimeMs=0 ("all at the beginning").
- processSpeed's minSegmentDuration merge extended last.end to a short follow-up segment without checking adjacency, bridging across hideSteps gaps and pulling the hidden source range back into rendered slices.

filterSteps now also drops actions whose startTime falls inside a hidden range. hideSteps re-runs processSpeed when speedUp already ran. buildTimeRemap snaps gap times to the next segment's outputStart. processSpeed only merges short segments into the previous one when they are adjacent.