### PR TITLE
feat(narrate): global narrateAutoWait default via setupRecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ import { test } from 'playwright-bdd'
 import { setupRecast, narrate, highlight, zoom, pace } from 'playwright-recast'
 
 setupRecast(test)
+// Or set a global narrate autoWait default for the whole suite (off by default):
+// setupRecast(test, { narrateAutoWait: true })
 export { narrate, highlight, zoom, pace }
 
 // steps/my-steps.ts

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,6 +3,12 @@ import type { Page, Locator, TestInfo } from '@playwright/test'
 type StepFn = <T>(title: string, body: () => T | Promise<T>) => Promise<T>
 type RecastTest = { info: () => TestInfo; step: StepFn }
 
+/** Accepted shapes for `narrate`'s autoWait — see `narrate()` for semantics. */
+type NarrateAutoWait =
+  | boolean
+  | number
+  | { charactersPerSecond?: number; minMs?: number; maxMs?: number }
+
 /**
  * Get current test info — works in both playwright-bdd and standard Playwright.
  * Must be called from within a test context.
@@ -15,6 +21,9 @@ function getTestInfo(): TestInfo {
 
 let _getTestInfo: () => TestInfo = getTestInfo
 let _step: StepFn | null = null
+/** Global default for `narrate`'s autoWait, applied when a call omits its own
+ *  `autoWait`. Set via setupRecast; undefined (off) by default. */
+let _narrateAutoWait: NarrateAutoWait | undefined = undefined
 
 /**
  * Title prefix written to a trace step by `narrate()`. The `subtitlesFromTrace`
@@ -54,10 +63,19 @@ function estimateNarrationMs(text: string, charsPerSecond: number): number {
  * import { setupRecast } from 'playwright-recast'
  * setupRecast(test)
  * ```
+ *
+ * @param options.narrateAutoWait Default `autoWait` applied to every `narrate()`
+ *   call that omits its own (default: off). Same shapes as `narrate`'s
+ *   per-call `autoWait`: `true`, a number of ms, or `{ charactersPerSecond,
+ *   minMs, maxMs }`. A per-call `autoWait` (including `false`) overrides this.
  */
-export function setupRecast(testInstance: RecastTest): void {
+export function setupRecast(
+  testInstance: RecastTest,
+  options?: { narrateAutoWait?: NarrateAutoWait },
+): void {
   _getTestInfo = () => testInstance.info()
   _step = testInstance.step.bind(testInstance)
+  _narrateAutoWait = options?.narrateAutoWait
 }
 
 /**
@@ -78,12 +96,15 @@ export function setupRecast(testInstance: RecastTest): void {
  *   - `true` — estimate via non-whitespace characters / `NARRATE_DEFAULT_CPS`.
  *   - `number` — wait exactly this many milliseconds.
  *   - `{ charactersPerSecond, minMs, maxMs }` — tune the estimate.
+ *   When omitted, the global default from `setupRecast({ narrateAutoWait })`
+ *   applies. Pass `false` to disable the wait for this call regardless of the
+ *   global default.
  */
 export async function narrate(
   text: string | undefined,
   opts?: {
     hidden?: boolean
-    autoWait?: boolean | number | { charactersPerSecond?: number; minMs?: number; maxMs?: number }
+    autoWait?: NarrateAutoWait
   },
 ): Promise<void> {
   const hidden = opts?.hidden ?? text?.includes('@hidden') ?? false
@@ -110,7 +131,10 @@ export async function narrate(
     await _step(`${prefix}${cleanText}`, async () => {})
   }
 
-  const waitMs = resolveAutoWait(cleanText, opts?.autoWait)
+  // A per-call autoWait (including an explicit `false`) overrides the global
+  // default; omitting it falls back to setupRecast's narrateAutoWait.
+  const autoWait = opts?.autoWait ?? _narrateAutoWait
+  const waitMs = resolveAutoWait(cleanText, autoWait)
   if (waitMs > 0) {
     await new Promise((resolve) => setTimeout(resolve, waitMs))
   }
@@ -118,11 +142,7 @@ export async function narrate(
 
 function resolveAutoWait(
   text: string,
-  autoWait:
-    | boolean
-    | number
-    | { charactersPerSecond?: number; minMs?: number; maxMs?: number }
-    | undefined,
+  autoWait: NarrateAutoWait | undefined,
 ): number {
   if (!autoWait) return 0
   if (typeof autoWait === 'number') return Math.max(0, autoWait)

--- a/tests/unit/helpers/narrate.test.ts
+++ b/tests/unit/helpers/narrate.test.ts
@@ -171,3 +171,51 @@ describe('narrate({ autoWait })', () => {
     expect(elapsed).toBeLessThan(500)
   })
 })
+
+describe('narrate({ autoWait }) — global default via setupRecast', () => {
+  let env: ReturnType<typeof makeFakeTest>
+
+  beforeEach(() => {
+    env = makeFakeTest()
+  })
+
+  it('applies the global narrateAutoWait when no per-call autoWait is given', async () => {
+    setupRecast(env.fakeTest, { narrateAutoWait: 120 })
+    const t0 = Date.now()
+    await narrate('hello')
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeGreaterThanOrEqual(110)
+    expect(elapsed).toBeLessThan(400)
+  })
+
+  it('lets a per-call autoWait override the global default', async () => {
+    setupRecast(env.fakeTest, { narrateAutoWait: 500 })
+    const t0 = Date.now()
+    await narrate('hello', { autoWait: 60 })
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeGreaterThanOrEqual(50)
+    expect(elapsed).toBeLessThan(300)
+  })
+
+  it('lets a per-call autoWait:false disable the wait even with a global default', async () => {
+    setupRecast(env.fakeTest, { narrateAutoWait: 500 })
+    const t0 = Date.now()
+    await narrate('hello', { autoWait: false })
+    expect(Date.now() - t0).toBeLessThan(50)
+  })
+
+  it('does not wait when neither global nor per-call autoWait is set', async () => {
+    setupRecast(env.fakeTest)
+    const t0 = Date.now()
+    await narrate('Hello world this is a longer line')
+    expect(Date.now() - t0).toBeLessThan(50)
+  })
+
+  it('resets the global default to off when setupRecast is called without it', async () => {
+    setupRecast(env.fakeTest, { narrateAutoWait: 500 })
+    setupRecast(env.fakeTest) // re-setup without the option clears it
+    const t0 = Date.now()
+    await narrate('hello')
+    expect(Date.now() - t0).toBeLessThan(50)
+  })
+})

--- a/website/content/docs/helpers/narrate.mdx
+++ b/website/content/docs/helpers/narrate.mdx
@@ -31,7 +31,7 @@ await narrate(undefined)
 |-----------|------|-------------|
 | `text` | `string \| undefined` | Voiceover text for this step. Pass `undefined` to no-op. |
 | `opts.hidden` | `boolean` | Mark the step as hidden (excluded from subtitles). Detected automatically if `text` contains `@hidden`. |
-| `opts.autoWait` | `boolean \| number \| object` | Pause after recording the marker step for the approximate time the line takes to speak. See below. |
+| `opts.autoWait` | `boolean \| number \| object` | Pause after recording the marker step for the approximate time the line takes to speak. When omitted, the global default from [`setupRecast({ narrateAutoWait })`](/docs/helpers/setup-recast#narrateautowait--a-global-autowait-default) applies. See below. |
 
 ## autoWait — visual time without TTS
 
@@ -48,6 +48,10 @@ await narrate('Welcome to the new dashboard.', {
   autoWait: { charactersPerSecond: 16, minMs: 1500, maxMs: 6000 },
 })
 ```
+
+### Setting a global default
+
+To pad every line without repeating `autoWait` on each call, set it once via [`setupRecast({ narrateAutoWait })`](/docs/helpers/setup-recast#narrateautowait--a-global-autowait-default). Any `narrate()` that omits `autoWait` falls back to that default; a per-call `autoWait` still overrides it, and `autoWait: false` opts a single call out of the wait entirely.
 
 ## Voiceover-driven freezes
 

--- a/website/content/docs/helpers/setup-recast.mdx
+++ b/website/content/docs/helpers/setup-recast.mdx
@@ -27,6 +27,39 @@ import { setupRecast } from 'playwright-recast'
 setupRecast(test)
 ```
 
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `narrateAutoWait` | `boolean \| number \| object` | off | Default [`autoWait`](/docs/helpers/narrate#autowait--visual-time-without-tts) applied to every `narrate()` call that omits its own. |
+
+### narrateAutoWait — a global autoWait default
+
+Instead of repeating `{ autoWait: true }` on every `narrate()` call, set it once for the whole suite. Each `narrate()` that omits its own `autoWait` falls back to this default:
+
+```typescript
+import { test } from 'playwright-bdd'
+import { setupRecast } from 'playwright-recast'
+
+// Every narrate() pads the test with the estimated speak time…
+setupRecast(test, { narrateAutoWait: true })
+
+// …or tune the estimate globally, same shapes as narrate's per-call autoWait:
+setupRecast(test, {
+  narrateAutoWait: { charactersPerSecond: 16, minMs: 1500, maxMs: 6000 },
+})
+```
+
+A per-call `autoWait` always wins — including an explicit `false`, which disables the wait for that one call regardless of the global default:
+
+```typescript
+await narrate('This line uses the global default.')
+await narrate('This line waits 2s.', { autoWait: 2000 })   // overrides the default
+await narrate('This line never waits.', { autoWait: false }) // opts out
+```
+
+The default is off, so suites that never set `narrateAutoWait` behave exactly as before. Calling `setupRecast(test)` again without the option resets the default back to off.
+
 ## How it works
 
 `setupRecast` receives the `test` object and uses `test.info()` internally to access the current test's annotations. The helpers (`narrate`, `zoom`, `highlight`) then write structured data to these annotations, which the pipeline reads during video generation.


### PR DESCRIPTION
Add an optional `narrateAutoWait` to `setupRecast(test, { narrateAutoWait })` that supplies the default `autoWait` for every `narrate()` call which omits its own. A per-call `autoWait` (including an explicit `false`) overrides the global default, so existing call sites are unaffected. Off by default.