### PR TITLE
fix(render): keep click/cursor overlays in sync with voiceover freezes

### DIFF
--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -443,6 +443,27 @@ export class PipelineExecutor {
             }
           }
 
+          // Output video time = timeRemap(trace) minus the output time of the
+          // recording's first frame. The renderer drops any visible segment
+          // that falls before that frame (negative source time), so raw
+          // timeRemap values sit `videoStartOutput` ms ahead of the rendered
+          // video. The SRT, cursor, and click paths all subtract this offset;
+          // narration subtitles, highlights, and zoom must do the same, or the
+          // freezes and click ripples derived from them drift behind the video.
+          let subVideoStartOutput = 0
+          if (state.speedMapped && state.speedMapped.speedSegments.length > 0 && state.parsed) {
+            const subFrames = state.parsed.frames
+            const subRecPageId = subFrames.length > 0
+              ? subFrames[subFrames.length - 1]!.pageId : undefined
+            const subRecFrames = subRecPageId
+              ? subFrames.filter((f) => f.pageId === subRecPageId) : subFrames
+            const subFirstRecFrameMs = subRecFrames[0]?.timestamp as number ??
+              (state.parsed.metadata.startTime as number)
+            subVideoStartOutput = state.speedMapped.timeRemap(toMonotonic(subFirstRecFrameMs))
+          }
+          const toVideoMs = (traceMs: number): number =>
+            Math.max(0, speedMapped.timeRemap(toMonotonic(traceMs)) - subVideoStartOutput)
+
           // If the test used narrate(), prefer the explicit narration spans.
           // narrate() emits a test.step with a marker-prefixed title; each
           // narrate's subtitle spans from its start until the next narrate
@@ -457,13 +478,13 @@ export class PipelineExecutor {
           )
 
           if (hasVisibleNarrate) {
-            const traceEndMs = speedMapped.timeRemap(speedMapped.metadata.endTime)
+            const traceEndMs = toVideoMs(speedMapped.metadata.endTime as number)
             const subtitles = buildNarrationSubtitles(
               boundaryActions.map((a) => ({
                 title: a.title as string,
                 startTime: a.startTime as number,
               })),
-              (t) => speedMapped.timeRemap(toMonotonic(t)),
+              (t) => toVideoMs(t),
               traceEndMs,
             )
             state.subtitled = { ...speedMapped, subtitles }
@@ -488,7 +509,7 @@ export class PipelineExecutor {
                 color?: string; opacity?: number; duration?: number
                 fadeOut?: number; swipeDuration?: number
               }
-              const videoTimeMs = Math.max(0, Math.round(speedMapped.timeRemap(action.startTime)))
+              const videoTimeMs = Math.round(toVideoMs(action.startTime as number))
               const duration = data.duration ?? hlDefaults.duration
               const fadeOut = data.fadeOut ?? hlDefaults.fadeOut
               traceHighlights.push({
@@ -521,7 +542,7 @@ export class PipelineExecutor {
                 const data = JSON.parse(action.title.slice(ZOOM_TITLE_PREFIX.length)) as {
                   x: number; y: number; level: number
                 }
-                const tMs = speedMapped.timeRemap(action.startTime)
+                const tMs = toVideoMs(action.startTime as number)
                 const sub = state.subtitled.subtitles.find(
                   (s) => tMs >= s.startMs && tMs < s.endMs,
                 )
@@ -972,9 +993,10 @@ export class PipelineExecutor {
           // Approach holds: each click marker becomes a video hold so the cursor
           // can glide over the painted target. Computed here (not in the renderer)
           // so generateVoiceover inserts matching audio silence + shifts subtitles.
-          // Positions use the subtitle formula (timeRemap, minus blank lead-in,
-          // minus a 2ms margin so the click ripple/cursor reliably shift into the
-          // hold) — the same timeline the subtitles live in.
+          // Positions use the click/cursor formula (timeRemap, minus the
+          // recording's first-frame output offset, minus blank lead-in, minus a
+          // 2ms margin so the click ripple/cursor reliably shift into the hold)
+          // — the same video timeline the clicks and cursor keyframes live in.
           const approachHolds: Array<{ atVideoMs: number; durationMs: number }> = []
           if (state.cursorOverlayConfig) {
             const approachMs = state.cursorOverlayConfig.approachMs ?? 500
@@ -985,9 +1007,15 @@ export class PipelineExecutor {
             const recFrames = recPageId
               ? state.parsed!.frames.filter((f) => f.pageId === recPageId) : state.parsed!.frames
             const recStart = recFrames[0]?.timestamp as number ?? 0
+            // Output time of the recording's first frame — same offset the click
+            // and cursor stages subtract. Only meaningful once speed segments exist.
+            const holdVideoStartOutput =
+              state.speedMapped && state.speedMapped.speedSegments.length > 0
+                ? remap(recStart)
+                : 0
             const markerActions = state.filtered?.actions ?? state.parsed!.actions
             for (const m of parseClickMarkersFromRecordingContext(markerActions, recStart)) {
-              const at = Math.round(remap(m.startTime)) - blankMs - 2
+              const at = Math.round(remap(m.startTime) - holdVideoStartOutput) - blankMs - 2
               approachHolds.push({ atVideoMs: Math.max(0, at), durationMs: Math.round(approachMs) })
             }
           }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -476,11 +476,84 @@ function renderWithSpeed(
   return concatOutput
 }
 
+/** One video slice to encode when applying voiceover freezes. */
+export interface FreezeSegmentPlan {
+  /** Source-video start (seconds), inclusive. */
+  startSec: number
+  /** Source-video end (seconds), exclusive; null means "to end of video". */
+  endSec: number | null
+  /** Clone-pad held before the slice's first frame (a leading hold). */
+  startHoldSec: number
+  /** Clone-pad held after the slice's last frame. */
+  stopHoldSec: number
+}
+
 /**
- * Hold the last frame at each freeze point so the narration audio has time to
- * finish before the next visual action. Splits the video at each freeze
- * position, holds the last frame of the preceding segment for the requested
- * duration, then concatenates everything back together.
+ * Pure planner for {@link applyVoiceoverFreezes}: turn freeze points into the
+ * list of video slices (with clone-pad holds) to encode and concatenate.
+ *
+ * A freeze at (or coinciding with) the start of the current slice — most
+ * commonly the leading intro narration whose visual window collapsed to ~0 —
+ * cannot be realised as a stop-pad on an empty preceding slice. Such holds are
+ * folded into a *start*-pad on the first frame of the next emitted slice
+ * (`start_mode=clone`), so the opening frame is held while the intro plays.
+ * This is critical: shiftForFreezes() shifts every click/cursor by the full set
+ * of freezes, so dropping any hold here (the previous behaviour) desynced the
+ * overlays from the video by that hold's duration.
+ *
+ * The total held time always equals the sum of all in-range freeze durations,
+ * which is exactly what shiftForFreezes() applies to the overlays.
+ */
+export function planVoiceoverFreezes(
+  freezes: Array<{ atVideoMs: number; durationMs: number }>,
+  videoDur: number,
+): { segments: FreezeSegmentPlan[]; totalHoldSec: number } {
+  // Collapse freezes onto distinct cut positions (rounded to the ms), summing
+  // durations that land together. Keep atSec === 0 entries — those are leading
+  // holds, applied as a start-pad. Holds at/after the end are left to the
+  // renderer's end-of-video tpad.
+  const byPos = new Map<number, number>()
+  for (const f of freezes) {
+    const atSec = Math.max(0, Math.min(videoDur, f.atVideoMs / 1000))
+    const durSec = Math.max(0, f.durationMs / 1000)
+    if (durSec <= 0.01) continue
+    if (atSec >= videoDur - 0.01) continue
+    const key = Math.round(atSec * 1000)
+    byPos.set(key, (byPos.get(key) ?? 0) + durSec)
+  }
+  const cuts = [...byPos.entries()]
+    .map(([ms, durSec]) => ({ atSec: ms / 1000, durSec }))
+    .sort((a, b) => a.atSec - b.atSec)
+
+  const totalHoldSec = cuts.reduce((a, b) => a + b.durSec, 0)
+  if (cuts.length === 0) return { segments: [], totalHoldSec: 0 }
+
+  const segments: FreezeSegmentPlan[] = []
+  let prevEnd = 0
+  let pendingStartHold = 0 // holds at prevEnd that must start-pad the next slice
+  for (const c of cuts) {
+    if (c.atSec <= prevEnd + 0.01) {
+      // Coincides with the current slice's start (e.g. a leading freeze at 0).
+      // Hold the same frame by start-padding the next emitted slice.
+      pendingStartHold += c.durSec
+      continue
+    }
+    segments.push({ startSec: prevEnd, endSec: c.atSec, startHoldSec: pendingStartHold, stopHoldSec: c.durSec })
+    prevEnd = c.atSec
+    pendingStartHold = 0
+  }
+
+  if (prevEnd < videoDur - 0.01 || pendingStartHold > 0.01) {
+    segments.push({ startSec: prevEnd, endSec: null, startHoldSec: pendingStartHold, stopHoldSec: 0 })
+  }
+
+  return { segments, totalHoldSec }
+}
+
+/**
+ * Hold a frame at each freeze point so the narration audio has time to finish
+ * before the next visual action. Splits the video per {@link planVoiceoverFreezes},
+ * clone-pads the held frames, then concatenates everything back together.
  *
  * Freeze positions are in the speed-mapped (pre-freeze) video timeline.
  */
@@ -492,47 +565,29 @@ function applyVoiceoverFreezes(
   if (freezes.length === 0) return videoPath
 
   const videoDur = getVideoDuration(videoPath)
-  const sorted = [...freezes]
-    .map((f) => ({
-      atSec: Math.max(0, Math.min(videoDur, f.atVideoMs / 1000)),
-      durSec: Math.max(0, f.durationMs / 1000),
-    }))
-    .filter((f) => f.durSec > 0.01 && f.atSec < videoDur - 0.01)
-    .sort((a, b) => a.atSec - b.atSec)
-
-  if (sorted.length === 0) return videoPath
+  const { segments, totalHoldSec } = planVoiceoverFreezes(freezes, videoDur)
+  if (segments.length === 0) return videoPath
 
   const segPaths: string[] = []
-  let prevEnd = 0
-  for (let i = 0; i < sorted.length; i++) {
-    const f = sorted[i]!
-    if (f.atSec <= prevEnd + 0.01) continue
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!
     const segPath = path.join(tmpDir, `vo-freeze-seg-${i}.mp4`)
+    const pad: string[] = []
+    if (seg.startHoldSec > 0.01) pad.push(`start_mode=clone:start_duration=${seg.startHoldSec.toFixed(3)}`)
+    if (seg.stopHoldSec > 0.01) pad.push(`stop_mode=clone:stop_duration=${seg.stopHoldSec.toFixed(3)}`)
     ffmpeg([
-      '-y', '-ss', String(prevEnd), '-to', String(f.atSec),
+      '-y', '-ss', String(seg.startSec),
+      ...(seg.endSec !== null ? ['-to', String(seg.endSec)] : []),
       '-i', videoPath,
-      '-vf', `tpad=stop_mode=clone:stop_duration=${f.durSec.toFixed(3)}`,
+      ...(pad.length > 0 ? ['-vf', `tpad=${pad.join(':')}`] : []),
       '-c:v', 'libx264', '-preset', 'fast', '-crf', '18', '-an',
       segPath,
     ])
     segPaths.push(segPath)
-    prevEnd = f.atSec
   }
 
-  if (prevEnd < videoDur - 0.01) {
-    const tailPath = path.join(tmpDir, 'vo-freeze-seg-tail.mp4')
-    ffmpeg([
-      '-y', '-ss', String(prevEnd),
-      '-i', videoPath,
-      '-c:v', 'libx264', '-preset', 'fast', '-crf', '18', '-an',
-      tailPath,
-    ])
-    segPaths.push(tailPath)
-  }
-
-  const totalFreezeSec = sorted.reduce((a, b) => a + b.durSec, 0)
   console.log(
-    `  Voiceover freeze: ${sorted.length} hold(s), +${totalFreezeSec.toFixed(1)}s`,
+    `  Voiceover freeze: ${segments.length} slice(s), +${totalHoldSec.toFixed(1)}s held`,
   )
 
   const concatList = path.join(tmpDir, 'vo-freeze-concat.txt')

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -142,6 +142,7 @@ export function probeResolution(videoPath: string): { width: number; height: num
   return { width: w!, height: h! }
 }
 
+
 /**
  * Render with smooth zoom transitions in a single ffmpeg pass.
  * Uses dynamic crop expressions with easing for animated zoom in/out/pan.
@@ -512,11 +513,14 @@ export function planVoiceoverFreezes(
   // durations that land together. Keep atSec === 0 entries — those are leading
   // holds, applied as a start-pad. Holds at/after the end are left to the
   // renderer's end-of-video tpad.
+  // Keep every freeze with a positive hold: shiftForFreezes() shifts the
+  // overlays by the full ms-resolution list, so dropping a small hold here
+  // would hold the video less than the overlays shift and desync them.
   const byPos = new Map<number, number>()
   for (const f of freezes) {
     const atSec = Math.max(0, Math.min(videoDur, f.atVideoMs / 1000))
     const durSec = Math.max(0, f.durationMs / 1000)
-    if (durSec <= 0.01) continue
+    if (durSec <= 0) continue
     if (atSec >= videoDur - 0.01) continue
     const key = Math.round(atSec * 1000)
     byPos.set(key, (byPos.get(key) ?? 0) + durSec)
@@ -573,8 +577,8 @@ function applyVoiceoverFreezes(
     const seg = segments[i]!
     const segPath = path.join(tmpDir, `vo-freeze-seg-${i}.mp4`)
     const pad: string[] = []
-    if (seg.startHoldSec > 0.01) pad.push(`start_mode=clone:start_duration=${seg.startHoldSec.toFixed(3)}`)
-    if (seg.stopHoldSec > 0.01) pad.push(`stop_mode=clone:stop_duration=${seg.stopHoldSec.toFixed(3)}`)
+    if (seg.startHoldSec > 0) pad.push(`start_mode=clone:start_duration=${seg.startHoldSec.toFixed(3)}`)
+    if (seg.stopHoldSec > 0) pad.push(`stop_mode=clone:stop_duration=${seg.stopHoldSec.toFixed(3)}`)
     ffmpeg([
       '-y', '-ss', String(seg.startSec),
       ...(seg.endSec !== null ? ['-to', String(seg.endSec)] : []),

--- a/tests/unit/render/freeze-plan.test.ts
+++ b/tests/unit/render/freeze-plan.test.ts
@@ -47,6 +47,18 @@ describe('planVoiceoverFreezes', () => {
     expect(segments[segments.length - 1]!.endSec).toBeNull()
   })
 
+  it('keeps small (sub-10ms) freezes so the hold matches the overlay shift', () => {
+    // shiftForFreezes() shifts overlays by the full ms freeze list; the planner
+    // must not drop small holds or the video would hold less than the overlays
+    // shift. (Regression: a <= 0.01s threshold dropped these.)
+    const { segments, totalHoldSec } = planVoiceoverFreezes(
+      [{ atVideoMs: 5000, durationMs: 4 }],
+      19.7,
+    )
+    expect(totalHoldSec).toBeCloseTo(0.004, 4)
+    expect(segments.reduce((a, s) => a + s.startHoldSec + s.stopHoldSec, 0)).toBeCloseTo(0.004, 4)
+  })
+
   it('ignores freezes at/after the end of the video (handled by end tpad)', () => {
     const { segments, totalHoldSec } = planVoiceoverFreezes(
       [{ atVideoMs: 19700, durationMs: 3000 }],

--- a/tests/unit/render/freeze-plan.test.ts
+++ b/tests/unit/render/freeze-plan.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { planVoiceoverFreezes } from '../../../src/render/renderer'
+
+const sum = (fs: Array<{ durationMs: number }>) =>
+  fs.reduce((a, f) => a + f.durationMs, 0) / 1000
+
+const totalApplied = (segs: Array<{ startHoldSec: number; stopHoldSec: number }>) =>
+  segs.reduce((a, s) => a + s.startHoldSec + s.stopHoldSec, 0)
+
+describe('planVoiceoverFreezes', () => {
+  it('applies a leading freeze at position 0 as a start-pad (regression: was dropped)', () => {
+    // The intro narration's window collapses to ~0, so its overflow freeze
+    // lands at videoMs 0. Previously this was skipped (empty leading slice),
+    // but shiftForFreezes() still shifted every click by it — desyncing the
+    // overlays from the video by the full hold. The hold MUST be applied.
+    const freezes = [
+      { atVideoMs: 0, durationMs: 7296 },
+      { atVideoMs: 760, durationMs: 3936 },
+      { atVideoMs: 947, durationMs: 500 },
+    ]
+    const { segments, totalHoldSec } = planVoiceoverFreezes(freezes, 19.7)
+
+    // Every freeze duration is realised — nothing dropped.
+    expect(totalHoldSec).toBeCloseTo(sum(freezes), 3)
+    expect(totalApplied(segments)).toBeCloseTo(sum(freezes), 3)
+
+    // The leading 7.296s hold is a start-pad on the first emitted slice.
+    expect(segments[0]!.startSec).toBe(0)
+    expect(segments[0]!.startHoldSec).toBeCloseTo(7.296, 3)
+  })
+
+  it('sums coincident freezes onto one cut instead of dropping the duplicate', () => {
+    const freezes = [
+      { atVideoMs: 5000, durationMs: 500 },
+      { atVideoMs: 5000, durationMs: 800 },
+    ]
+    const { segments, totalHoldSec } = planVoiceoverFreezes(freezes, 19.7)
+    expect(totalHoldSec).toBeCloseTo(1.3, 3)
+    expect(totalApplied(segments)).toBeCloseTo(1.3, 3)
+  })
+
+  it('holds the last frame of the preceding slice for a mid-video freeze', () => {
+    const { segments } = planVoiceoverFreezes([{ atVideoMs: 5000, durationMs: 2000 }], 19.7)
+    expect(segments[0]).toMatchObject({ startSec: 0, endSec: 5, startHoldSec: 0 })
+    expect(segments[0]!.stopHoldSec).toBeCloseTo(2, 3)
+    // Tail runs to end of video.
+    expect(segments[segments.length - 1]!.endSec).toBeNull()
+  })
+
+  it('ignores freezes at/after the end of the video (handled by end tpad)', () => {
+    const { segments, totalHoldSec } = planVoiceoverFreezes(
+      [{ atVideoMs: 19700, durationMs: 3000 }],
+      19.7,
+    )
+    expect(segments).toHaveLength(0)
+    expect(totalHoldSec).toBe(0)
+  })
+
+  it('keeps the overlay-shift invariant: total held == sum of in-range freezes', () => {
+    const freezes = [
+      { atVideoMs: 0, durationMs: 6000 },
+      { atVideoMs: 0, durationMs: 1296 }, // two leading holds
+      { atVideoMs: 760, durationMs: 3936 },
+      { atVideoMs: 5641, durationMs: 4032 },
+      { atVideoMs: 10580, durationMs: 500 },
+    ]
+    const { segments, totalHoldSec } = planVoiceoverFreezes(freezes, 19.7)
+    expect(totalApplied(segments)).toBeCloseTo(sum(freezes), 3)
+    expect(totalHoldSec).toBeCloseTo(sum(freezes), 3)
+    // Both leading holds fold into the first slice's start-pad.
+    expect(segments[0]!.startHoldSec).toBeCloseTo(7.296, 3)
+  })
+})


### PR DESCRIPTION
Clicks and cursor lagged the video by several seconds when speedUp + voiceover were combined. Two root causes:

1. Dropped leading freeze. An intro narration's audio overflows a visual window that collapses to ~0, producing a freeze at video position 0. applyVoiceoverFreezes skipped it (can't clone-pad an empty leading slice), but shiftForFreezes still shifted every click/cursor by its full duration — so the overlays landed seconds after the content they belonged to. Now a leading/coincident hold is applied as a start-pad on the first frame (tpad=start_mode=clone), so the opening frame holds while the intro plays and the total held time equals what the overlays are shifted by. The freeze-planning is extracted into the pure planVoiceoverFreezes() with regression tests.

2. Frame-of-reference mismatch. subtitlesFromTrace (narration subtitles, highlights, zoom) and the approach holds used raw timeRemap time, while the SRT, cursor, and click stages subtract videoStartOutput (the output time the renderer drops for content before the first recording frame). subtitlesFromTrace and the approach holds now subtract it too, matching the other stages.