### PR TITLE
fix(click-effect): sound every click, including rapid ones

### DIFF
--- a/src/click-effect/sound-track.ts
+++ b/src/click-effect/sound-track.ts
@@ -3,7 +3,6 @@ import { execFileSync } from 'node:child_process'
 export interface ClickSoundInput {
   clicks: Array<{ videoTimeMs: number }>
   soundPath: string
-  soundDurationMs: number
   outputPath: string
   volume: number
 }
@@ -40,10 +39,7 @@ export function buildClickSoundPlan(
  * together (`adelay` + `amix`), so overlapping clicks both sound. `normalize=0`
  * keeps each click at full volume; coincident clicks sum.
  */
-export function generateClickSoundTrack(
-  input: ClickSoundInput,
-  _tmpDir: string,
-): string {
+export function generateClickSoundTrack(input: ClickSoundInput): string {
   const { delaysMs } = buildClickSoundPlan(input.clicks)
   if (delaysMs.length === 0) return ''
 

--- a/src/click-effect/sound-track.ts
+++ b/src/click-effect/sound-track.ts
@@ -1,5 +1,3 @@
-import * as fs from 'node:fs'
-import * as path from 'node:path'
 import { execFileSync } from 'node:child_process'
 
 export interface ClickSoundInput {
@@ -11,85 +9,67 @@ export interface ClickSoundInput {
 }
 
 export interface ClickSoundPlan {
-  /** Silence duration (ms) before each click sound */
-  silenceDurations: number[]
-  /** Filtered clicks (overlapping ones removed) */
-  filteredClicks: Array<{ videoTimeMs: number }>
+  /** Absolute start time (ms) for each click sound, sorted ascending. */
+  delaysMs: number[]
 }
 
 /**
- * Plan the click sound track: compute silence durations between clicks,
- * remove overlapping clicks.
+ * Plan the click sound track: one sound per click, placed at the click's exact
+ * video time.
+ *
+ * Unlike a sequential silence+sound concatenation, this keeps EVERY click —
+ * including ones spaced closer than the sound's duration. Those simply overlap
+ * (mixed by {@link generateClickSoundTrack}), matching the ripple overlays,
+ * which are likewise drawn for every click regardless of spacing. Dropping
+ * close clicks here is what left rapid clicks (e.g. focus-then-type) with a
+ * visible ripple but no audible click.
  */
-export function buildClickSoundArgs(input: ClickSoundInput): ClickSoundPlan {
-  const sorted = [...input.clicks].sort((a, b) => a.videoTimeMs - b.videoTimeMs)
-
-  const filtered: Array<{ videoTimeMs: number }> = []
-  const silenceDurations: number[] = []
-  let cursor = 0
-
-  for (const click of sorted) {
-    // Skip if this click overlaps with the previous sound
-    if (filtered.length > 0 && click.videoTimeMs < cursor) {
-      continue
-    }
-
-    const silenceMs = Math.max(0, click.videoTimeMs - cursor)
-    silenceDurations.push(silenceMs)
-    filtered.push(click)
-    cursor = click.videoTimeMs + input.soundDurationMs
-  }
-
-  return { silenceDurations, filteredClicks: filtered }
+export function buildClickSoundPlan(
+  clicks: Array<{ videoTimeMs: number }>,
+): ClickSoundPlan {
+  const delaysMs = clicks
+    .map((c) => Math.max(0, Math.round(c.videoTimeMs)))
+    .sort((a, b) => a - b)
+  return { delaysMs }
 }
 
 /**
  * Generate the click sound audio track.
- * Concatenates silence + click sound segments using ffmpeg concat demuxer.
+ *
+ * Delays a copy of the click sound to each click's video time and mixes them
+ * together (`adelay` + `amix`), so overlapping clicks both sound. `normalize=0`
+ * keeps each click at full volume; coincident clicks sum.
  */
 export function generateClickSoundTrack(
   input: ClickSoundInput,
-  tmpDir: string,
+  _tmpDir: string,
 ): string {
-  const plan = buildClickSoundArgs(input)
-  if (plan.filteredClicks.length === 0) return ''
+  const { delaysMs } = buildClickSoundPlan(input.clicks)
+  if (delaysMs.length === 0) return ''
 
-  const segmentFiles: string[] = []
+  const n = delaysMs.length
+  const vol = Math.abs(input.volume - 1.0) > 0.01 ? `,volume=${input.volume}` : ''
 
-  for (let i = 0; i < plan.filteredClicks.length; i++) {
-    const silenceMs = plan.silenceDurations[i]!
-
-    // Add silence before this click
-    if (silenceMs > 0) {
-      const silencePath = path.join(tmpDir, `click-silence-${i}.mp3`)
-      execFileSync('ffmpeg', [
-        '-y', '-f', 'lavfi', '-i',
-        `anullsrc=r=44100:cl=mono,atrim=0:${(silenceMs / 1000).toFixed(3)}`,
-        '-c:a', 'libmp3lame', '-q:a', '2', silencePath,
-      ], { stdio: 'pipe' })
-      segmentFiles.push(silencePath)
+  let filterComplex: string
+  if (n === 1) {
+    filterComplex = `[0:a]adelay=${delaysMs[0]}:all=1${vol}[out]`
+  } else {
+    const labels = Array.from({ length: n }, (_, i) => `[s${i}]`).join('')
+    const parts: string[] = [`[0:a]asplit=${n}${labels}`]
+    for (let i = 0; i < n; i++) {
+      parts.push(`[s${i}]adelay=${delaysMs[i]}:all=1${vol}[d${i}]`)
     }
-
-    // Add click sound (with volume adjustment)
-    if (Math.abs(input.volume - 1.0) > 0.01) {
-      const volPath = path.join(tmpDir, `click-vol-${i}.mp3`)
-      execFileSync('ffmpeg', [
-        '-y', '-i', input.soundPath,
-        '-af', `volume=${input.volume}`,
-        '-c:a', 'libmp3lame', '-q:a', '2', volPath,
-      ], { stdio: 'pipe' })
-      segmentFiles.push(volPath)
-    } else {
-      segmentFiles.push(input.soundPath)
-    }
+    const mixIn = Array.from({ length: n }, (_, i) => `[d${i}]`).join('')
+    parts.push(
+      `${mixIn}amix=inputs=${n}:duration=longest:normalize=0:dropout_transition=0[out]`,
+    )
+    filterComplex = parts.join(';')
   }
 
-  // Concat all segments
-  const concatList = path.join(tmpDir, 'click-concat.txt')
-  fs.writeFileSync(concatList, segmentFiles.map(f => `file '${path.basename(f)}'`).join('\n'))
-
   execFileSync('ffmpeg', [
-    '-y', '-f', 'concat', '-safe', '0', '-i', concatList,
+    '-y', '-i', input.soundPath,
+    '-filter_complex', filterComplex,
+    '-map', '[out]',
     '-c:a', 'libmp3lame', '-q:a', '2',
     input.outputPath,
   ], { stdio: 'pipe' })

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -747,17 +747,13 @@ export function renderVideo(
       soundPath = trace.clickEffectConfig.sound
     }
 
-    const soundDurationMs = getClickAudioDurationMs(soundPath)
-
     clickSoundTrackPath = generateClickSoundTrack(
       {
         clicks: trace.clickEvents,
         soundPath,
-        soundDurationMs,
         outputPath: path.join(tmpDir, 'click-sound-track.mp3'),
         volume: trace.clickEffectConfig.soundVolume,
       },
-      tmpDir,
     )
     if (clickSoundTrackPath) {
       console.log(`  Click sound: ${trace.clickEvents.length} sounds mixed`)

--- a/tests/unit/click-effect/sound-track.test.ts
+++ b/tests/unit/click-effect/sound-track.test.ts
@@ -1,66 +1,41 @@
 import { describe, it, expect } from 'vitest'
-import { buildClickSoundArgs } from '../../../src/click-effect/sound-track'
+import { buildClickSoundPlan } from '../../../src/click-effect/sound-track'
 
-describe('buildClickSoundArgs', () => {
-  it('creates correct silence durations for clicks at given timestamps', () => {
-    const result = buildClickSoundArgs({
-      clicks: [
-        { videoTimeMs: 1000 },
-        { videoTimeMs: 5000 },
-        { videoTimeMs: 8000 },
-      ],
-      soundPath: '/tmp/click.mp3',
-      soundDurationMs: 50,
-      outputPath: '/tmp/click-track.mp3',
-      volume: 0.8,
-    })
-
-    expect(result.silenceDurations).toHaveLength(3)
-    expect(result.silenceDurations[0]).toBe(1000)
-    expect(result.silenceDurations[1]).toBe(3950) // 5000 - (1000+50)
-    expect(result.silenceDurations[2]).toBe(2950) // 8000 - (5000+50)
+describe('buildClickSoundPlan', () => {
+  it('places one sound per click at the click time', () => {
+    const result = buildClickSoundPlan([
+      { videoTimeMs: 1000 },
+      { videoTimeMs: 5000 },
+      { videoTimeMs: 8000 },
+    ])
+    expect(result.delaysMs).toEqual([1000, 5000, 8000])
   })
 
-  it('handles single click at t=0', () => {
-    const result = buildClickSoundArgs({
-      clicks: [{ videoTimeMs: 0 }],
-      soundPath: '/tmp/click.mp3',
-      soundDurationMs: 50,
-      outputPath: '/tmp/click-track.mp3',
-      volume: 0.8,
-    })
-    expect(result.silenceDurations).toHaveLength(1)
-    expect(result.silenceDurations[0]).toBe(0)
+  it('handles a single click at t=0', () => {
+    expect(buildClickSoundPlan([{ videoTimeMs: 0 }]).delaysMs).toEqual([0])
   })
 
-  it('skips clicks too close together (within sound duration)', () => {
-    const result = buildClickSoundArgs({
-      clicks: [
-        { videoTimeMs: 1000 },
-        { videoTimeMs: 1020 }, // only 20ms after, sound is 50ms
-        { videoTimeMs: 3000 },
-      ],
-      soundPath: '/tmp/click.mp3',
-      soundDurationMs: 50,
-      outputPath: '/tmp/click-track.mp3',
-      volume: 0.8,
-    })
-    expect(result.silenceDurations).toHaveLength(2) // second click skipped
-    expect(result.filteredClicks).toHaveLength(2)
+  it('keeps clicks spaced closer than the sound duration (regression: were dropped)', () => {
+    // focus-then-type and other rapid clicks must each get a sound; they
+    // simply overlap when mixed, matching the ripple overlays.
+    const result = buildClickSoundPlan([
+      { videoTimeMs: 15846 },
+      { videoTimeMs: 16665 }, // 819ms later; default sound is ~1489ms
+    ])
+    expect(result.delaysMs).toEqual([15846, 16665])
   })
 
   it('sorts unsorted clicks', () => {
-    const result = buildClickSoundArgs({
-      clicks: [
-        { videoTimeMs: 5000 },
-        { videoTimeMs: 1000 },
-        { videoTimeMs: 3000 },
-      ],
-      soundPath: '/tmp/click.mp3',
-      soundDurationMs: 50,
-      outputPath: '/tmp/click-track.mp3',
-      volume: 0.8,
-    })
-    expect(result.filteredClicks.map(c => c.videoTimeMs)).toEqual([1000, 3000, 5000])
+    const result = buildClickSoundPlan([
+      { videoTimeMs: 5000 },
+      { videoTimeMs: 1000 },
+      { videoTimeMs: 3000 },
+    ])
+    expect(result.delaysMs).toEqual([1000, 3000, 5000])
+  })
+
+  it('rounds and clamps negative times to zero', () => {
+    expect(buildClickSoundPlan([{ videoTimeMs: -5 }, { videoTimeMs: 12.4 }]).delaysMs)
+      .toEqual([0, 12])
   })
 })


### PR DESCRIPTION
The click sound track was built by sequential silence+sound concat, which can't represent overlapping sounds, so it dropped any click spaced closer than the sound's full duration (~1.5s for the bundled sound). A focus-then-type click 0.8s after the prior click got a visible ripple but no audible click.

Place each click sound at its exact time via adelay + amix (normalize=0) so coincident clicks overlap instead of dropping — matching the ripple overlays, which are drawn for every click. Replace buildClickSoundArgs (concat planner that dropped clicks) with buildClickSoundPlan (one delay per click); update tests.