### PR TITLE
feat(cursor-overlay): animate between pointer positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ await Recast
 - **Styled subtitle burn-in** — Configurable font, size, color, background box with opacity, padding, position. Smart punctuation-based chunking for single-line display.
 - **playwright-bdd support** — First-class integration with playwright-bdd Gherkin steps. Doc strings become voiceover narration.
 - **Click highlighting** — Animated ripple effect at click positions with optional click sound. Configurable color, opacity, radius, duration.
-- **Cursor overlay** — Animated cursor appears before each click, moves to the click position with ease-out animation, then disappears. Bundled arrow cursor or custom image.
+- **Cursor overlay** — Animated cursor travels between click positions with configurable duration, easing, and post-arrival visibility. Bundled arrow cursor or custom image.
 - **Animated zoom with easing** — Auto-zoom uses customizable easing functions (ease-in-out, ease-out, cubic-bezier, or custom JS functions) with smooth zoom-to-zoom panning.
 - **Frame interpolation** — Smooth out choppy browser recordings with ffmpeg minterpolate. Blend, duplicate, or motion-compensated modes with multi-pass support.
 - **Step helpers** — `narrate()`, `highlight()`, `zoom()`, `pace()`, `click()`, `markClick()`, `waitForNarration()` — importable helpers for Playwright step definitions. `narrate/highlight/zoom/click` write marker steps directly into the trace zip, so the pipeline picks them up automatically via `subtitlesFromTrace()` (no `report.json` or extra pipeline calls needed).

--- a/src/cursor-overlay/defaults.ts
+++ b/src/cursor-overlay/defaults.ts
@@ -7,13 +7,14 @@ export const DEFAULT_CURSOR_OVERLAY = {
   color: '#FFFFFF',
   opacity: 0.9,
   easing: 'ease-in-out' as const,
+  moveDurationMs: 250,
   hideAfterMs: 500,
   shadow: true,
   approachMs: 500,
 } as const
 
 export type ResolvedCursorOverlayConfig = Required<
-  Pick<CursorOverlayConfig, 'size' | 'color' | 'opacity' | 'easing' | 'hideAfterMs' | 'shadow' | 'approachMs'>
+  Pick<CursorOverlayConfig, 'size' | 'color' | 'opacity' | 'easing' | 'moveDurationMs' | 'hideAfterMs' | 'shadow' | 'approachMs'>
 > & CursorOverlayConfig
 
 /** Merge user config with defaults */
@@ -26,6 +27,7 @@ export function resolveCursorOverlayConfig(
     color: config.color ?? DEFAULT_CURSOR_OVERLAY.color,
     opacity: config.opacity ?? DEFAULT_CURSOR_OVERLAY.opacity,
     easing: config.easing ?? DEFAULT_CURSOR_OVERLAY.easing,
+    moveDurationMs: config.moveDurationMs ?? DEFAULT_CURSOR_OVERLAY.moveDurationMs,
     hideAfterMs: config.hideAfterMs ?? DEFAULT_CURSOR_OVERLAY.hideAfterMs,
     shadow: config.shadow ?? DEFAULT_CURSOR_OVERLAY.shadow,
     approachMs: config.approachMs ?? DEFAULT_CURSOR_OVERLAY.approachMs,

--- a/src/cursor-overlay/expression-builder.ts
+++ b/src/cursor-overlay/expression-builder.ts
@@ -6,16 +6,22 @@ interface Resolution {
   height: number
 }
 
-/** How long before a click the cursor appears (seconds) */
+/** Default pre-click lead used to avoid animating across a loading page. */
 const APPEAR_BEFORE = 0.5
-/** How long after a click the cursor stays visible (seconds) */
-const VISIBLE_AFTER = 0.2
-/** How long the cursor moves to the click position (seconds) */
-const MOVE_DURATION = 0.25
-/** Offset in viewport px — cursor arrives from this offset above-left */
-const ARRIVE_OFFSET = 40
+/** Offset in viewport px used before the first recorded pointer position. */
+const INITIAL_OFFSET = 40
 /** Smallest pre-click lead, even when the target appeared at the last moment */
 const MIN_LEAD = 0.15
+/** Keep ffmpeg interpolation denominators non-zero for coincident positions. */
+const MIN_MOVE_DURATION = 0.05
+
+interface TrajectoryPoint {
+  x: number
+  y: number
+  t: number
+  lead: number
+  glide: boolean
+}
 
 /**
  * How long before a click the cursor should appear, trimmed by the action's
@@ -29,13 +35,13 @@ function appearLead(autoWaitSec: number | undefined): number {
 }
 
 /**
- * Build ffmpeg overlay x/y expressions for per-click cursor animation.
- * Cursor appears briefly before each click, moves quickly to click position,
- * then disappears shortly after.
+ * Build ffmpeg overlay x/y expressions for animated cursor movement.
+ * Each recorded pointer position is reached at its trace timestamp. Movement
+ * starts at the previous position and lasts no longer than moveDurationMs.
  */
 export function buildOverlayExpressions(
   keyframes: CursorKeyframe[],
-  _config: ResolvedCursorOverlayConfig,
+  config: ResolvedCursorOverlayConfig,
   viewport: Resolution,
   srcRes: Resolution,
 ): { x: string; y: string } {
@@ -58,50 +64,74 @@ export function buildOverlayExpressions(
       y: Math.max(0, Math.round(kf.y * scaleY)),
       t: Number(kf.videoTimeSec.toFixed(4)),
       lead,
-      // Move can't outlast the lead, otherwise the cursor would still be
-      // gliding when the click fires.
-      moveDur: Math.min(MOVE_DURATION, lead),
       glide,
     }
   })
 
   return {
-    x: buildPerClickAxis(points, 'x', scaleX),
-    y: buildPerClickAxis(points, 'y', scaleY),
+    x: buildTrajectoryAxis(points, 'x', scaleX, config),
+    y: buildTrajectoryAxis(points, 'y', scaleY, config),
   }
 }
 
-function buildPerClickAxis(
-  points: Array<{ x: number; y: number; t: number; lead: number; moveDur: number; glide: boolean }>,
+function moveDuration(
+  points: Array<Pick<TrajectoryPoint, 't' | 'lead'>>,
+  index: number,
+  configuredDuration: number,
+): number {
+  const available = index === 0
+    ? configuredDuration
+    : Math.max(MIN_MOVE_DURATION, points[index]!.t - points[index - 1]!.t)
+  return Math.min(configuredDuration, points[index]!.lead, available)
+}
+
+function progressExpression(easing: ResolvedCursorOverlayConfig['easing']): string {
+  switch (easing) {
+    case 'linear':
+      return 'ld(0)'
+    case 'ease-out':
+      return '(1-(1-ld(0))*(1-ld(0)))'
+    case 'ease-in-out':
+    default:
+      return '(3*ld(0)*ld(0)-2*ld(0)*ld(0)*ld(0))'
+  }
+}
+
+function buildTrajectoryAxis(
+  points: TrajectoryPoint[],
   axis: 'x' | 'y',
   scale: number,
+  config: ResolvedCursorOverlayConfig,
 ): string {
   if (points.length === 0) return '0'
 
-  const baseOffset = Math.round(ARRIVE_OFFSET * scale)
+  const configuredDuration = Math.max(MIN_MOVE_DURATION, config.moveDurationMs / 1000)
+  const visibleAfter = Math.max(0, config.hideAfterMs / 1000)
+  const initialOffset = Math.round(INITIAL_OFFSET * scale)
+  const easedProgress = progressExpression(config.easing)
   const segments: string[] = []
 
-  for (const p of points) {
-    const target = p[axis]
-    const offset = p.glide ? baseOffset : 0 // no slide-in for late-appearing targets
-    const start = target - offset // arrive from above-left
-    const moveStart = p.t - p.lead
-    const moveEnd = moveStart + p.moveDur
-
-    // During movement: ease-out from offset to target
-    // After movement: stay at target until disappear
+  // Later movements take priority when pointer visibility windows overlap.
+  for (let i = points.length - 1; i >= 0; i--) {
+    const point = points[i]!
+    const target = point[axis]
+    const previous = i === 0 ? target - initialOffset : points[i - 1]![axis]
+    // A target that appeared only after a long auto-wait has no stable page
+    // context to glide across, so retain the existing appear-at-target guard.
+    const start = point.glide ? previous : target
+    const duration = moveDuration(points, i, configuredDuration)
+    const moveStart = point.t - duration
     const segment =
-      `if(between(t\\,${moveStart.toFixed(4)}\\,${moveEnd.toFixed(4)})\\,` +
-      `st(0\\,(t-${moveStart.toFixed(4)})/${p.moveDur.toFixed(4)})\\;` +
-      `${start}+(${offset})*(1-(1-ld(0))*(1-ld(0)))\\,` + // ease-out
+      `if(between(t\\,${moveStart.toFixed(4)}\\,${point.t.toFixed(4)})\\,` +
+      `st(0\\,(t-${moveStart.toFixed(4)})/${duration.toFixed(4)})\\;` +
+      `${start}+(${target - start})*${easedProgress}\\,` +
       `${target})`
 
     segments.push(
-      `if(between(t\\,${moveStart.toFixed(4)}\\,${(p.t + VISIBLE_AFTER).toFixed(4)})\\,${segment}\\,`
+      `if(between(t\\,${moveStart.toFixed(4)}\\,${(point.t + visibleAfter).toFixed(4)})\\,${segment}\\,`
     )
   }
 
-  // Default position (when hidden, doesn't matter but need valid value)
   let expr = segments.join('')
   expr += '0'
   expr += ')'.repeat(segments.length)
@@ -110,17 +140,25 @@ function buildPerClickAxis(
 }
 
 /**
- * Build the enable expression for per-click cursor visibility.
- * Cursor is visible from APPEAR_BEFORE before each click to VISIBLE_AFTER after.
+ * Cursor is visible while travelling to each position and until hideAfterMs
+ * after it arrives.
  */
 export function buildEnableExpression(
   keyframes: CursorKeyframe[],
+  config: ResolvedCursorOverlayConfig,
 ): string {
   if (keyframes.length === 0) return '0'
 
-  const windows = keyframes.map(kf => {
-    const start = (kf.videoTimeSec - appearLead(kf.autoWaitSec)).toFixed(4)
-    const end = (kf.videoTimeSec + VISIBLE_AFTER).toFixed(4)
+  const configuredDuration = Math.max(MIN_MOVE_DURATION, config.moveDurationMs / 1000)
+  const visibleAfter = Math.max(0, config.hideAfterMs / 1000)
+  const points = keyframes.map(kf => ({
+    t: Number(kf.videoTimeSec.toFixed(4)),
+    lead: appearLead(kf.autoWaitSec),
+  }))
+  const windows = points.map((point, index) => {
+    const duration = moveDuration(points, index, configuredDuration)
+    const start = (point.t - duration).toFixed(4)
+    const end = (point.t + visibleAfter).toFixed(4)
     return `between(t\\,${start}\\,${end})`
   })
 
@@ -136,5 +174,5 @@ export interface FadeTiming {
 }
 
 export function buildFadeTiming(): null {
-  return null // No longer used — visibility is per-click via enable expression
+  return null
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -235,7 +235,7 @@ function renderWithCursorOverlay(
 
   // Build per-click position and visibility expressions
   const { x: xExpr, y: yExpr } = buildOverlayExpressions(keyframes, config, viewport, srcRes)
-  const enableExpr = buildEnableExpression(keyframes)
+  const enableExpr = buildEnableExpression(keyframes, config)
 
   const escapedClipPath = cursorClipPath.replace(/'/g, "'\\''").replace(/\\/g, '\\\\')
 

--- a/src/types/cursor-overlay.ts
+++ b/src/types/cursor-overlay.ts
@@ -13,7 +13,9 @@ export interface CursorOverlayConfig {
   opacity?: number
   /** Interpolation easing between positions. Default: 'ease-in-out' */
   easing?: 'linear' | 'ease-in-out' | 'ease-out'
-  /** Ms after last action before cursor fades out. Default: 500 */
+  /** Maximum time spent travelling to the next pointer position in ms. Default: 250 */
+  moveDurationMs?: number
+  /** Ms after reaching a position before the cursor hides. Default: 500 */
   hideAfterMs?: number
   /** Show drop shadow on the default cursor dot. Default: true */
   shadow?: boolean

--- a/tests/unit/cursor-overlay/defaults.test.ts
+++ b/tests/unit/cursor-overlay/defaults.test.ts
@@ -8,6 +8,7 @@ describe('resolveCursorOverlayConfig', () => {
     expect(resolved.color).toBe('#FFFFFF')
     expect(resolved.opacity).toBe(0.9)
     expect(resolved.easing).toBe('ease-in-out')
+    expect(resolved.moveDurationMs).toBe(250)
     expect(resolved.hideAfterMs).toBe(500)
     expect(resolved.shadow).toBe(true)
   })
@@ -35,6 +36,11 @@ describe('resolveCursorOverlayConfig', () => {
     expect(resolveCursorOverlayConfig({}).approachMs).toBe(500)
     expect(resolveCursorOverlayConfig({ approachMs: 800 }).approachMs).toBe(800)
   })
+
+  it('defaults moveDurationMs to 250 and honors an override', () => {
+    expect(resolveCursorOverlayConfig({}).moveDurationMs).toBe(250)
+    expect(resolveCursorOverlayConfig({ moveDurationMs: 600 }).moveDurationMs).toBe(600)
+  })
 })
 
 describe('DEFAULT_CURSOR_OVERLAY', () => {
@@ -43,6 +49,7 @@ describe('DEFAULT_CURSOR_OVERLAY', () => {
     expect(DEFAULT_CURSOR_OVERLAY.color).toBeDefined()
     expect(DEFAULT_CURSOR_OVERLAY.opacity).toBeDefined()
     expect(DEFAULT_CURSOR_OVERLAY.easing).toBeDefined()
+    expect(DEFAULT_CURSOR_OVERLAY.moveDurationMs).toBeDefined()
     expect(DEFAULT_CURSOR_OVERLAY.hideAfterMs).toBeDefined()
     expect(DEFAULT_CURSOR_OVERLAY.shadow).toBeDefined()
   })

--- a/tests/unit/cursor-overlay/expression-builder.test.ts
+++ b/tests/unit/cursor-overlay/expression-builder.test.ts
@@ -14,63 +14,204 @@ describe('buildOverlayExpressions', () => {
     expect(result.y).toBe('0')
   })
 
-  it('builds per-click segments for single keyframe', () => {
-    const keyframes = [{ x: 640, y: 360, videoTimeSec: 5.0 }]
-    const result = buildOverlayExpressions(keyframes, defaultConfig, viewport, srcRes)
-    expect(result.x).toContain('between(t')
-    expect(result.y).toContain('between(t')
+  it('moves the first keyframe from the scaled initial offset', () => {
+    const result = buildOverlayExpressions(
+      [{ x: 100, y: 200, videoTimeSec: 5 }],
+      defaultConfig,
+      viewport,
+      srcRes,
+    )
+
+    // 1.5x source scaling: target x=150, initial offset=60, start x=90.
+    expect(result.x).toContain('90+(60)*')
+    // Target y=300, start y=240.
+    expect(result.y).toContain('240+(60)*')
   })
 
-  it('builds per-click segments for multiple keyframes', () => {
-    const keyframes = [
-      { x: 100, y: 100, videoTimeSec: 2.0 },
-      { x: 500, y: 400, videoTimeSec: 5.0 },
-    ]
-    const result = buildOverlayExpressions(keyframes, defaultConfig, viewport, srcRes)
-    // Two click windows = two between() blocks
-    const betweenCount = (result.x.match(/between\(t/g) || []).length
-    expect(betweenCount).toBeGreaterThanOrEqual(2)
+  it('moves later keyframes from the previous pointer position', () => {
+    const result = buildOverlayExpressions(
+      [
+        { x: 100, y: 100, videoTimeSec: 2 },
+        { x: 500, y: 400, videoTimeSec: 5 },
+      ],
+      defaultConfig,
+      viewport,
+      srcRes,
+    )
+
+    // Previous scaled x=150, target scaled x=750.
+    expect(result.x).toContain('150+(600)*')
+    // Previous scaled y=150, target scaled y=600.
+    expect(result.y).toContain('150+(450)*')
   })
 
-  it('uses ease-out (st/ld pattern) for movement', () => {
-    const keyframes = [{ x: 500, y: 400, videoTimeSec: 3.0 }]
-    const result = buildOverlayExpressions(keyframes, defaultConfig, viewport, srcRes)
-    expect(result.x).toContain('st(0')
-    expect(result.x).toContain('ld(0)')
+  it('honors a custom move duration and reaches the target at its timestamp', () => {
+    const config = resolveCursorOverlayConfig({ moveDurationMs: 400 })
+    const result = buildOverlayExpressions(
+      [{ x: 100, y: 100, videoTimeSec: 5 }],
+      config,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain('between(t\\,4.6000\\,5.0000)')
+    expect(result.x).toContain('(t-4.6000)/0.4000')
+  })
+
+  it('clamps movement to the interval between closely spaced keyframes', () => {
+    const result = buildOverlayExpressions(
+      [
+        { x: 100, y: 100, videoTimeSec: 2 },
+        { x: 200, y: 200, videoTimeSec: 2.1 },
+      ],
+      defaultConfig,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain('between(t\\,2.0000\\,2.1000)')
+    expect(result.x).toContain('(t-2.0000)/0.1000')
+  })
+
+  it('uses a 50ms safety floor for coincident keyframes', () => {
+    const result = buildOverlayExpressions(
+      [
+        { x: 100, y: 100, videoTimeSec: 2 },
+        { x: 200, y: 200, videoTimeSec: 2 },
+      ],
+      defaultConfig,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain('between(t\\,1.9500\\,2.0000)')
+    expect(result.x).toContain('(t-1.9500)/0.0500')
+  })
+
+  it('uses a 50ms safety floor for non-positive configured durations', () => {
+    const config = resolveCursorOverlayConfig({ moveDurationMs: 0 })
+    const result = buildOverlayExpressions(
+      [{ x: 100, y: 100, videoTimeSec: 5 }],
+      config,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain('between(t\\,4.9500\\,5.0000)')
+    expect(result.x).toContain('(t-4.9500)/0.0500')
+  })
+
+  it.each([
+    ['linear', '*ld(0)'],
+    ['ease-out', '*(1-(1-ld(0))*(1-ld(0)))'],
+    ['ease-in-out', '*(3*ld(0)*ld(0)-2*ld(0)*ld(0)*ld(0))'],
+  ] as const)('uses %s easing', (easing, expected) => {
+    const config = resolveCursorOverlayConfig({ easing })
+    const result = buildOverlayExpressions(
+      [{ x: 500, y: 400, videoTimeSec: 3 }],
+      config,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain(expected)
+  })
+
+  it('uses the configured post-arrival visibility time', () => {
+    const config = resolveCursorOverlayConfig({ hideAfterMs: 750 })
+    const result = buildOverlayExpressions(
+      [{ x: 100, y: 100, videoTimeSec: 5 }],
+      config,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain('between(t\\,4.7500\\,5.7500)')
+  })
+
+  it('clamps a negative post-arrival visibility time to zero', () => {
+    const config = resolveCursorOverlayConfig({ hideAfterMs: -100 })
+    const result = buildOverlayExpressions(
+      [{ x: 100, y: 100, videoTimeSec: 5 }],
+      config,
+      viewport,
+      srcRes,
+    )
+
+    expect(result.x).toContain('between(t\\,4.7500\\,5.0000)')
+  })
+
+  it('keeps the cursor at the target after a long auto-wait', () => {
+    const result = buildOverlayExpressions(
+      [{ x: 100, y: 100, videoTimeSec: 5, autoWaitSec: 2 }],
+      defaultConfig,
+      viewport,
+      srcRes,
+    )
+
+    // The target only just painted, so do not glide over the loading screen.
+    expect(result.x).toContain('150+(0)*')
+    expect(result.x).toContain('between(t\\,4.8500\\,5.0000)')
+  })
+
+  it('gives later movements priority when visibility windows overlap', () => {
+    const config = resolveCursorOverlayConfig({ moveDurationMs: 500, hideAfterMs: 500 })
+    const result = buildOverlayExpressions(
+      [
+        { x: 100, y: 100, videoTimeSec: 2 },
+        { x: 200, y: 200, videoTimeSec: 2.2 },
+      ],
+      config,
+      viewport,
+      srcRes,
+    )
+
+    // Nested ffmpeg if() branches are evaluated from left to right.
+    expect(result.x.indexOf('2.0000\\,2.7000')).toBeLessThan(
+      result.x.indexOf('1.5000\\,2.5000'),
+    )
   })
 })
 
 describe('buildEnableExpression', () => {
   it('returns 0 for empty keyframes', () => {
-    expect(buildEnableExpression([])).toBe('0')
+    expect(buildEnableExpression([], defaultConfig)).toBe('0')
   })
 
-  it('creates visibility window for single click', () => {
-    const keyframes = [{ x: 100, y: 100, videoTimeSec: 5.0 }]
-    const result = buildEnableExpression(keyframes)
-    expect(result).toContain('between(t')
-    // Window should start before 5.0 and end after 5.0
-    expect(result).toContain('4.5')
-    expect(result).toContain('5.2')
+  it('uses configured movement and visibility timing', () => {
+    const config = resolveCursorOverlayConfig({ moveDurationMs: 400, hideAfterMs: 750 })
+    const result = buildEnableExpression(
+      [{ x: 100, y: 100, videoTimeSec: 5 }],
+      config,
+    )
+
+    expect(result).toBe('between(t\\,4.6000\\,5.7500)')
   })
 
-  it('creates multiple windows for multiple clicks', () => {
+  it('creates multiple windows for multiple keyframes', () => {
     const keyframes = [
-      { x: 100, y: 100, videoTimeSec: 2.0 },
-      { x: 500, y: 400, videoTimeSec: 8.0 },
+      { x: 100, y: 100, videoTimeSec: 2 },
+      { x: 500, y: 400, videoTimeSec: 8 },
     ]
-    const result = buildEnableExpression(keyframes)
-    const windows = result.split('+')
-    expect(windows).toHaveLength(2)
+    const result = buildEnableExpression(keyframes, defaultConfig)
+    expect(result.split('+')).toHaveLength(2)
   })
 
   it('shortens the pre-click lead when the target appeared after a long wait', () => {
-    // 2s of auto-wait means the target only became visible near the click, so
-    // the cursor should appear ~0.15s before (clamped MIN_LEAD) rather than
-    // the default 0.5s, to avoid showing on the still-loading screen.
-    const keyframes = [{ x: 100, y: 100, videoTimeSec: 5.0, autoWaitSec: 2.0 }]
-    const result = buildEnableExpression(keyframes)
-    expect(result).toContain('4.8500') // 5.0 - 0.15
-    expect(result).not.toContain('4.5000') // not the full 0.5 lead
+    const keyframes = [{ x: 100, y: 100, videoTimeSec: 5, autoWaitSec: 2 }]
+    const result = buildEnableExpression(keyframes, defaultConfig)
+    expect(result).toContain('4.8500')
+    expect(result).not.toContain('4.7500')
+  })
+
+  it('matches the position expression visibility window', () => {
+    const config = resolveCursorOverlayConfig({ moveDurationMs: 350, hideAfterMs: 600 })
+    const keyframes = [{ x: 100, y: 100, videoTimeSec: 5 }]
+    const position = buildOverlayExpressions(keyframes, config, viewport, srcRes)
+    const enable = buildEnableExpression(keyframes, config)
+
+    expect(enable).toBe('between(t\\,4.6500\\,5.6000)')
+    expect(position.x).toContain(enable)
+    expect(position.y).toContain(enable)
   })
 })

--- a/website/content/docs/api-reference/recast-class.mdx
+++ b/website/content/docs/api-reference/recast-class.mdx
@@ -200,7 +200,8 @@ Render an animated cursor that moves between action positions.
 | `color` | `string` | `'#FFFFFF'` | Dot color (hex) |
 | `opacity` | `number` | `0.9` | Opacity 0.0-1.0 |
 | `easing` | `string` | `'ease-in-out'` | Movement easing |
-| `hideAfterMs` | `number` | `500` | Fade-out delay after last action |
+| `moveDurationMs` | `number` | `250` | Maximum travel time to the next pointer position |
+| `hideAfterMs` | `number` | `500` | Visible time after reaching a position |
 | `shadow` | `boolean` | `true` | Drop shadow on cursor |
 | `approachMs` | `number` | `500` | Hold duration for marker-driven clicks ([`click()`](/docs/helpers/click)) — the cursor glides over the held, painted target |
 | `filter` | `(action: TraceAction) => boolean` | — | Filter which actions generate cursor positions |

--- a/website/content/docs/api-reference/types.mdx
+++ b/website/content/docs/api-reference/types.mdx
@@ -440,8 +440,10 @@ interface CursorOverlayConfig {
   color?: string                            // Default: '#FFFFFF'
   opacity?: number                          // Default: 0.9
   easing?: 'linear' | 'ease-in-out' | 'ease-out'  // Default: 'ease-in-out'
+  moveDurationMs?: number                   // Default: 250
   hideAfterMs?: number                      // Default: 500
   shadow?: boolean                          // Default: true
+  approachMs?: number                       // Default: 500
   filter?: (action: TraceAction) => boolean
 }
 ```

--- a/website/content/docs/examples/full-pipeline.mdx
+++ b/website/content/docs/examples/full-pipeline.mdx
@@ -61,6 +61,7 @@ await Recast
     opacity: 0.9,
     shadow: true,
     easing: 'ease-out',
+    moveDurationMs: 250,
     hideAfterMs: 500,
     approachMs: 500,   // held approach for click()-marked clicks
   })

--- a/website/content/docs/guides/click-effects-and-cursor.mdx
+++ b/website/content/docs/guides/click-effects-and-cursor.mdx
@@ -92,9 +92,12 @@ await Recast
   opacity: 0.9,         // Opacity 0.0-1.0. Default: 0.9
   shadow: true,         // Drop shadow. Default: true
   easing: 'ease-out',   // Movement easing. Default: 'ease-in-out'
-  hideAfterMs: 500,     // Fade out delay after last action. Default: 500
+  moveDurationMs: 250,  // Maximum travel time to each position. Default: 250
+  hideAfterMs: 500,     // Visible time after reaching a position. Default: 500
 })
 ```
+
+The first position arrives from a small upper-left offset. Each later movement starts at the preceding pointer position and lands at the next action timestamp. `moveDurationMs` is capped to the available time between closely spaced actions, while `hideAfterMs` controls how long the cursor remains visible after landing.
 
 ### Custom cursor image
 
@@ -155,10 +158,10 @@ import { click } from 'playwright-recast'
 await click(page.getByRole('button', { name: 'Get started' }))
 ```
 
-For each marked click, the renderer **holds the painted frame** at the click and lets the cursor play its full approach over it, then fires the ripple — a deliberate "point and click" beat instead of a glide over a loading screen. The hold duration is `approachMs` on `cursorOverlay`:
+For each marked click, the renderer **holds the painted frame** at the click and lets the cursor play its full approach over it, then fires the ripple — a deliberate "point and click" beat instead of a glide over a loading screen. The hold duration is `approachMs` on `cursorOverlay`. Keep it at least as large as `moveDurationMs` so the complete movement plays over the held frame:
 
 ```typescript
-.cursorOverlay({ approachMs: 600 })   // default 500ms
+.cursorOverlay({ moveDurationMs: 300, approachMs: 600 })
 .clickEffect({ sound: true })
 ```
 

--- a/website/content/docs/pipeline/cursor-overlay.mdx
+++ b/website/content/docs/pipeline/cursor-overlay.mdx
@@ -3,7 +3,7 @@ title: Cursor Overlay
 description: Add an animated cursor that moves to click positions in the video.
 ---
 
-The `.cursorOverlay()` stage renders an animated cursor that appears before each click, moves to the click position with an ease-out animation, then disappears. It gives viewers a clear visual indicator of where interactions happen.
+The `.cursorOverlay()` stage renders an animated cursor that travels from one click position to the next and reaches each target at its trace timestamp. You can control the travel duration, easing, and how long the cursor remains visible after arrival.
 
 ## Basic usage
 
@@ -21,8 +21,25 @@ await Recast
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `image` | `string` | bundled arrow cursor | Path to a custom cursor image (PNG) |
-| `size` | `number` | `30` | Cursor width in pixels (relative to 1080p) |
+| `size` | `number` | `24` | Cursor width in pixels (relative to 1080p) |
+| `color` | `string` | `'#FFFFFF'` | Cursor color |
+| `opacity` | `number` | `0.9` | Cursor opacity from 0 to 1 |
+| `easing` | `'linear' \| 'ease-in-out' \| 'ease-out'` | `'ease-in-out'` | Easing used while travelling between positions |
+| `moveDurationMs` | `number` | `250` | Maximum time spent travelling to the next position |
+| `hideAfterMs` | `number` | `500` | Time the cursor remains visible after reaching a position |
+| `shadow` | `boolean` | `true` | Show a drop shadow on the default cursor |
 | `approachMs` | `number` | `500` | Hold (freeze) duration for marker-driven clicks — see [Held cursor approach](#approachms--held-cursor-approach) |
+| `filter` | `(action) => boolean` | — | Select which actions generate cursor positions |
+
+```typescript
+.cursorOverlay({
+  easing: 'ease-out',
+  moveDurationMs: 300,
+  hideAfterMs: 600,
+})
+```
+
+`moveDurationMs` is a maximum: closely spaced positions use the shorter interval between their timestamps. Values below 50 ms use a 50 ms safety floor for ffmpeg interpolation. Negative `hideAfterMs` values behave as `0`.
 
 ### Custom cursor image
 
@@ -39,7 +56,7 @@ The bundled default is a 30x44 arrow cursor PNG. Provide your own image for bran
 
 By default the cursor's approach is timed off each click action detected in the trace. For clicks that wait on a page load, that approach can glide over a still-loading screen before the target paints — "the mouse moves before there's anything to click on."
 
-The [`click()` / `markClick()`](/docs/helpers/click) test helpers fix this by writing an explicit click marker. For each marker, the renderer **holds (freezes) the painted frame** at the click for `approachMs` and lets the cursor play its full glide over it, then resumes into the click's result. `approachMs` defaults to 500 ms (it must be at least the cursor's pre-click span so the glide fits inside the hold).
+The [`click()` / `markClick()`](/docs/helpers/click) test helpers fix this by writing an explicit click marker. For each marker, the renderer **holds (freezes) the painted frame** at the click for `approachMs` and lets the cursor play its full glide over it, then resumes into the click's result. `approachMs` defaults to 500 ms; keep it at least as large as `moveDurationMs` so the full movement fits inside the hold.
 
 ```typescript
 .cursorOverlay({ approachMs: 600 })
@@ -51,11 +68,11 @@ The [`click()` / `markClick()`](/docs/helpers/click) test helpers fix this by wr
 
 For each click action detected in the trace:
 
-1. The cursor appears near the click target
-2. It moves to the exact click position with an ease-out animation
-3. It disappears after the click
+1. The first cursor position arrives from a small upper-left offset
+2. Later positions travel from the preceding pointer position with the configured easing
+3. The cursor reaches the target at the click timestamp and hides after `hideAfterMs`
 
-The animation uses ffmpeg `movie` + `overlay` filters with per-click `enable` expressions and ease-out movement calculated via `st()/ld()` temp variables.
+The animation uses ffmpeg `movie` + `overlay` filters with per-position `enable` expressions and easing calculated via `st()/ld()` temp variables. If Playwright spent a long time auto-waiting for a target to appear, the cursor appears directly at that target instead of gliding over the loading screen.
 
 ## CLI equivalent
 

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -1043,7 +1043,7 @@ The renderer applies zoom by cropping the video to `(width/level x height/level)
 ## Cursor Overlay
 
 
-The `.cursorOverlay()` stage renders an animated cursor that appears before each click, moves to the click position with an ease-out animation, then disappears. It gives viewers a clear visual indicator of where interactions happen.
+The `.cursorOverlay()` stage renders an animated cursor that travels from one click position to the next and reaches each target at its trace timestamp. You can control the travel duration, easing, and how long the cursor remains visible after arrival.
 
 ## Basic usage
 
@@ -1061,7 +1061,11 @@ await Recast
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `image` | `string` | bundled arrow cursor | Path to a custom cursor image (PNG) |
-| `size` | `number` | `30` | Cursor width in pixels (relative to 1080p) |
+| `size` | `number` | `24` | Cursor width in pixels (relative to 1080p) |
+| `easing` | `'linear' \| 'ease-in-out' \| 'ease-out'` | `'ease-in-out'` | Easing used while travelling between positions |
+| `moveDurationMs` | `number` | `250` | Maximum time spent travelling to the next position |
+| `hideAfterMs` | `number` | `500` | Time the cursor remains visible after reaching a position |
+| `approachMs` | `number` | `500` | Hold duration for marker-driven clicks |
 
 ### Custom cursor image
 
@@ -1078,11 +1082,11 @@ The bundled default is a 30x44 arrow cursor PNG. Provide your own image for bran
 
 For each click action detected in the trace:
 
-1. The cursor appears near the click target
-2. It moves to the exact click position with an ease-out animation
-3. It disappears after the click
+1. The first cursor position arrives from a small upper-left offset
+2. Later positions travel from the preceding pointer position with the configured easing
+3. The cursor reaches the target at the click timestamp and hides after `hideAfterMs`
 
-The animation uses ffmpeg `movie` + `overlay` filters with per-click `enable` expressions and ease-out movement calculated via `st()/ld()` temp variables.
+The animation uses ffmpeg `movie` + `overlay` filters with per-position `enable` expressions and easing calculated via `st()/ld()` temp variables. Long Playwright auto-waits retain the appear-at-target safeguard so the cursor does not glide over a loading screen.
 
 ## CLI equivalent
 
@@ -2107,8 +2111,10 @@ Render an animated cursor that moves between action positions.
 | `color` | `string` | `'#FFFFFF'` | Dot color (hex) |
 | `opacity` | `number` | `0.9` | Opacity 0.0-1.0 |
 | `easing` | `string` | `'ease-in-out'` | Movement easing |
-| `hideAfterMs` | `number` | `500` | Fade-out delay after last action |
+| `moveDurationMs` | `number` | `250` | Maximum travel time to the next pointer position |
+| `hideAfterMs` | `number` | `500` | Visible time after reaching a position |
 | `shadow` | `boolean` | `true` | Drop shadow on cursor |
+| `approachMs` | `number` | `500` | Hold duration for marker-driven clicks |
 | `filter` | `(action: TraceAction) => boolean` | — | Filter which actions generate cursor positions |
 
 ---
@@ -2727,8 +2733,10 @@ interface CursorOverlayConfig {
   color?: string                            // Default: '#FFFFFF'
   opacity?: number                          // Default: 0.9
   easing?: 'linear' | 'ease-in-out' | 'ease-out'  // Default: 'ease-in-out'
+  moveDurationMs?: number                   // Default: 250
   hideAfterMs?: number                      // Default: 500
   shadow?: boolean                          // Default: true
+  approachMs?: number                       // Default: 500
   filter?: (action: TraceAction) => boolean
 }
 ```
@@ -3794,7 +3802,9 @@ await Recast
     opacity: 0.9,
     shadow: true,
     easing: 'ease-out',
+    moveDurationMs: 250,
     hideAfterMs: 500,
+    approachMs: 500,
   })
 
   // 8. Click ripple effects with sound
@@ -4674,7 +4684,7 @@ By default, all click and selectOption actions with cursor coordinates are highl
 
 ## Cursor overlay
 
-The `.cursorOverlay()` stage renders an animated cursor that appears before each action, moves to the action position with easing, then disappears after a timeout.
+The `.cursorOverlay()` stage renders an animated cursor that travels from the previous action position to the next with configurable duration and easing, then hides after a configurable timeout.
 
 ### Basic usage
 
@@ -4696,7 +4706,8 @@ await Recast
   opacity: 0.9,         // Opacity 0.0-1.0. Default: 0.9
   shadow: true,         // Drop shadow. Default: true
   easing: 'ease-out',   // Movement easing. Default: 'ease-in-out'
-  hideAfterMs: 500,     // Fade out delay after last action. Default: 500
+  moveDurationMs: 250,  // Maximum travel time to each position. Default: 250
+  hideAfterMs: 500,     // Visible time after reaching a position. Default: 500
 })
 ```
 


### PR DESCRIPTION
## Summary

- add moveDurationMs with a 250ms default
- animate later cursor positions from the previous pointer position
- honor configured easing and hideAfterMs in ffmpeg expressions
- preserve marker-held approaches and long-auto-wait safeguards
- document cursor movement, visibility, and approach timing

## Validation

- npm test: 479 passed, 11 skipped
- npm run typecheck
- npm run build
- focused cursor tests: 50 passed
- ffmpeg expression smoke render
- website production build

No speed-rendering changes are included.