### PR TITLE
feat(helpers): hover the target before clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **`setupRecast({ hoverDwellMs })`** — `click()` now rests on its target before pressing it, so the app paints its own hover state (highlighted row, revealed button) into the recording. Off by default (`0`). The hover is best effort — an unhoverable target still goes through the normal `click()` actionability path — and the click marker is written after the dwell so `resolveClickMarkers()` still pairs it with the real click.
+
 ## 0.20.0 (2026-08-24)
 
 ### Features

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,7 +50,7 @@ let _clickSettleMs = DEFAULT_CLICK_SETTLE_MS
 const DEFAULT_TYPING_DELAY_MS = 100
 let _typingDelayMs = DEFAULT_TYPING_DELAY_MS
 const DEFAULT_HOVER_DWELL_MS = 0
-/** Cap on the cosmetic pre-click hover — the target is already visible. */
+/** Cap on the hover attempt itself — the dwell that follows is separate. */
 const HOVER_TIMEOUT_MS = 1000
 let _hoverDwellMs = DEFAULT_HOVER_DWELL_MS
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,6 +50,8 @@ let _clickSettleMs = DEFAULT_CLICK_SETTLE_MS
 const DEFAULT_TYPING_DELAY_MS = 100
 let _typingDelayMs = DEFAULT_TYPING_DELAY_MS
 const DEFAULT_HOVER_DWELL_MS = 0
+/** Cap on the cosmetic pre-click hover — the target is already visible. */
+const HOVER_TIMEOUT_MS = 1000
 let _hoverDwellMs = DEFAULT_HOVER_DWELL_MS
 
 /**
@@ -445,9 +447,12 @@ export async function click(
     await new Promise((resolve) => setTimeout(resolve, _clickSettleMs))
   }
   if (_hoverDwellMs > 0) {
-    // Best effort: `locator.click()` below runs the real actionability checks.
-    await locator.hover({ timeout: 5_000 }).catch(() => {})
-    await new Promise((resolve) => setTimeout(resolve, _hoverDwellMs))
+    // Best effort, and short: the target is visible and settled already, so a
+    // hover that does not land is obstructed and no hover state will appear —
+    // dwelling on it would only add latency ahead of the real click, which
+    // runs its own actionability checks.
+    const hovered = await locator.hover({ timeout: HOVER_TIMEOUT_MS }).then(() => true, () => false)
+    if (hovered) await new Promise((resolve) => setTimeout(resolve, _hoverDwellMs))
   }
   // After the dwell: resolveClickMarkers() only pairs a marker with a click
   // inside a short window, and an unpaired marker renders a second click.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -15,6 +15,9 @@ export interface SetupRecastOptions {
   clickSettleMs?: number
   /** Average delay between `typeText()` keystrokes in ms (default: 100). */
   typingDelayMs?: number
+  /** How long `click()` hovers its target before pressing, so the recording
+   *  shows the app's hover state (default: 0, off). */
+  hoverDwellMs?: number
 }
 
 /** Per-call options for `typeText()`. */
@@ -46,6 +49,8 @@ let _clickSettleMs = DEFAULT_CLICK_SETTLE_MS
  *  by +/- 35% to avoid a mechanical cadence. */
 const DEFAULT_TYPING_DELAY_MS = 100
 let _typingDelayMs = DEFAULT_TYPING_DELAY_MS
+const DEFAULT_HOVER_DWELL_MS = 0
+let _hoverDwellMs = DEFAULT_HOVER_DWELL_MS
 
 /**
  * Title prefix written to a trace step by `narrate()`. The `subtitlesFromTrace`
@@ -106,6 +111,8 @@ function estimateNarrationMs(text: string, charsPerSecond: number): number {
  *   (default: 150). Pass 0 to disable.
  * @param options.typingDelayMs Default average delay between `typeText()`
  *   keystrokes in ms (default: 100). A per-call `delayMs` overrides this.
+ * @param options.hoverDwellMs How long `click()` hovers the target before
+ *   pressing it, in ms (default: 0, off), so the app paints its hover state.
  */
 export function setupRecast(
   testInstance: RecastTest,
@@ -116,6 +123,7 @@ export function setupRecast(
   _narrateAutoWait = options?.narrateAutoWait
   _clickSettleMs = options?.clickSettleMs ?? DEFAULT_CLICK_SETTLE_MS
   _typingDelayMs = options?.typingDelayMs ?? DEFAULT_TYPING_DELAY_MS
+  _hoverDwellMs = options?.hoverDwellMs ?? DEFAULT_HOVER_DWELL_MS
 }
 
 /**
@@ -420,8 +428,9 @@ export async function markClick(locator: Locator): Promise<void> {
 /**
  * Perform a click that renders with a polished cursor approach. Waits for the
  * target to be visible, settles briefly (so the recorder captures the painted
- * target), marks the click, then performs the real `locator.click(options)`.
- * `options` is forwarded to Playwright unchanged.
+ * target), hovers it for `setupRecast({ hoverDwellMs })`, marks the click,
+ * then performs the real `locator.click(options)`. `options` is forwarded to
+ * Playwright unchanged.
  */
 export async function click(
   locator: Locator,
@@ -435,6 +444,13 @@ export async function click(
   if (_clickSettleMs > 0) {
     await new Promise((resolve) => setTimeout(resolve, _clickSettleMs))
   }
+  if (_hoverDwellMs > 0) {
+    // Best effort: `locator.click()` below runs the real actionability checks.
+    await locator.hover({ timeout: 5_000 }).catch(() => {})
+    await new Promise((resolve) => setTimeout(resolve, _hoverDwellMs))
+  }
+  // After the dwell: resolveClickMarkers() only pairs a marker with a click
+  // inside a short window, and an unpaired marker renders a second click.
   await markClick(locator)
   await locator.click(options)
 }

--- a/tests/unit/helpers/click.test.ts
+++ b/tests/unit/helpers/click.test.ts
@@ -29,6 +29,7 @@ function makeLocator(
   return {
     async boundingBox() { calls.push('boundingBox'); return box },
     async waitFor(opts: { state?: string }) { calls.push(`waitFor:${opts?.state}`) },
+    async hover() { calls.push('hover') },
     async click(options?: unknown) { calls.push('click'); sink.clickOptions = options },
   } as unknown as Locator
 }
@@ -80,6 +81,59 @@ describe('click()', () => {
     expect(sink.clickOptions).toEqual({ button: 'left', force: true })
     expect(elapsed).toBeGreaterThanOrEqual(15)
     expect(elapsed).toBeLessThan(300)
+  })
+
+  it('hovers the target before clicking when hoverDwellMs is set', async () => {
+    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 20 })
+    const sink: { clickOptions?: unknown } = {}
+    const loc = makeLocator({ x: 10, y: 10, width: 20, height: 20 }, env.calls, sink)
+
+    await click(loc)
+
+    expect(env.calls).toEqual([
+      'waitFor:visible',
+      'hover',
+      'boundingBox',
+      `step:${CLICK_TITLE_PREFIX}${JSON.stringify({ x: 20, y: 20 })}`,
+      'click',
+    ])
+  })
+
+  it('marks the click after the hover so the marker stays inside the reconciliation window', async () => {
+    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 40 })
+    const sink: { clickOptions?: unknown } = {}
+    const loc = makeLocator({ x: 10, y: 10, width: 20, height: 20 }, env.calls, sink)
+
+    await click(loc)
+
+    const hoverIndex = env.calls.indexOf('hover')
+    const markerIndex = env.calls.findIndex((c) => c.startsWith(`step:${CLICK_TITLE_PREFIX}`))
+    const clickIndex = env.calls.indexOf('click')
+    expect(hoverIndex).toBeLessThan(markerIndex)
+    expect(markerIndex).toBeLessThan(clickIndex)
+  })
+
+  it('clicks anyway when the hover cannot be performed', async () => {
+    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 5 })
+    const sink: { clickOptions?: unknown } = {}
+    const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
+    ;(loc as unknown as { hover: () => Promise<void> }).hover = async () => {
+      throw new Error('intercepted')
+    }
+
+    await click(loc)
+
+    expect(env.calls).toContain('click')
+  })
+
+  it('does not hover when hoverDwellMs is left at its default', async () => {
+    setupRecast(env.fakeTest, { clickSettleMs: 0 })
+    const sink: { clickOptions?: unknown } = {}
+    const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
+
+    await click(loc)
+
+    expect(env.calls).not.toContain('hover')
   })
 
   it('skips the settle wait when clickSettleMs is 0', async () => {

--- a/tests/unit/helpers/click.test.ts
+++ b/tests/unit/helpers/click.test.ts
@@ -84,12 +84,14 @@ describe('click()', () => {
   })
 
   it('hovers the target before clicking when hoverDwellMs is set', async () => {
-    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 20 })
+    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 60 })
     const sink: { clickOptions?: unknown } = {}
     const loc = makeLocator({ x: 10, y: 10, width: 20, height: 20 }, env.calls, sink)
 
+    const t0 = Date.now()
     await click(loc)
 
+    expect(Date.now() - t0).toBeGreaterThanOrEqual(50)
     expect(env.calls).toEqual([
       'waitFor:visible',
       'hover',

--- a/tests/unit/helpers/click.test.ts
+++ b/tests/unit/helpers/click.test.ts
@@ -24,12 +24,12 @@ function makeEnv() {
 function makeLocator(
   box: { x: number; y: number; width: number; height: number } | null,
   calls: string[],
-  sink: { clickOptions?: unknown },
+  sink: { clickOptions?: unknown; hoverOptions?: unknown },
 ): Locator {
   return {
     async boundingBox() { calls.push('boundingBox'); return box },
     async waitFor(opts: { state?: string }) { calls.push(`waitFor:${opts?.state}`) },
-    async hover() { calls.push('hover') },
+    async hover(options?: unknown) { calls.push('hover'); sink.hoverOptions = options },
     async click(options?: unknown) { calls.push('click'); sink.clickOptions = options },
   } as unknown as Locator
 }
@@ -39,7 +39,7 @@ describe('markClick()', () => {
   beforeEach(() => { env = makeEnv(); setupRecast(env.fakeTest) })
 
   it('writes one marker step with the element center as JSON', async () => {
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 100, y: 200, width: 40, height: 20 }, env.calls, sink)
     await markClick(loc)
     expect(env.steps).toHaveLength(1)
@@ -47,14 +47,14 @@ describe('markClick()', () => {
   })
 
   it('pushes no annotations', async () => {
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
     await markClick(loc)
     expect(env.info.annotations).toEqual([])
   })
 
   it('no-ops when boundingBox() is null', async () => {
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator(null, env.calls, sink)
     await markClick(loc)
     expect(env.steps).toEqual([])
@@ -67,7 +67,7 @@ describe('click()', () => {
 
   it('waits visible, settles, marks, then clicks — forwarding options', async () => {
     setupRecast(env.fakeTest, { clickSettleMs: 20 })
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 10, y: 10, width: 20, height: 20 }, env.calls, sink)
     const t0 = Date.now()
     await click(loc, { button: 'left', force: true })
@@ -85,13 +85,15 @@ describe('click()', () => {
 
   it('hovers the target before clicking when hoverDwellMs is set', async () => {
     setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 60 })
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 10, y: 10, width: 20, height: 20 }, env.calls, sink)
 
     const t0 = Date.now()
     await click(loc)
 
     expect(Date.now() - t0).toBeGreaterThanOrEqual(50)
+    // The hover attempt is capped on its own, well under the click's timeout.
+    expect(sink.hoverOptions).toEqual({ timeout: 1000 })
     expect(env.calls).toEqual([
       'waitFor:visible',
       'hover',
@@ -103,7 +105,7 @@ describe('click()', () => {
 
   it('marks the click after the hover so the marker stays inside the reconciliation window', async () => {
     setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 40 })
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 10, y: 10, width: 20, height: 20 }, env.calls, sink)
 
     await click(loc)
@@ -117,7 +119,7 @@ describe('click()', () => {
 
   it('clicks anyway when the hover cannot be performed, and skips the dwell', async () => {
     setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 300 })
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
     ;(loc as unknown as { hover: () => Promise<void> }).hover = async () => {
       throw new Error('intercepted')
@@ -132,7 +134,7 @@ describe('click()', () => {
 
   it('does not hover when hoverDwellMs is left at its default', async () => {
     setupRecast(env.fakeTest, { clickSettleMs: 0 })
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
 
     await click(loc)
@@ -142,7 +144,7 @@ describe('click()', () => {
 
   it('skips the settle wait when clickSettleMs is 0', async () => {
     setupRecast(env.fakeTest, { clickSettleMs: 0 })
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
     const t0 = Date.now()
     await click(loc)
@@ -159,7 +161,7 @@ describe('click helpers without setupRecast()', () => {
   it('markClick no-ops before reading the locator box when setupRecast was not called', async () => {
     const { markClick } = await import('../../../src/helpers')
     const calls: string[] = []
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 10, y: 20, width: 30, height: 40 }, calls, sink)
 
     await markClick(loc)
@@ -170,7 +172,7 @@ describe('click helpers without setupRecast()', () => {
   it('click falls back to the real locator click without settle or marker work', async () => {
     const { click } = await import('../../../src/helpers')
     const calls: string[] = []
-    const sink: { clickOptions?: unknown } = {}
+    const sink: { clickOptions?: unknown; hoverOptions?: unknown } = {}
     const loc = makeLocator({ x: 10, y: 20, width: 30, height: 40 }, calls, sink)
     const t0 = Date.now()
 

--- a/tests/unit/helpers/click.test.ts
+++ b/tests/unit/helpers/click.test.ts
@@ -113,17 +113,19 @@ describe('click()', () => {
     expect(markerIndex).toBeLessThan(clickIndex)
   })
 
-  it('clicks anyway when the hover cannot be performed', async () => {
-    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 5 })
+  it('clicks anyway when the hover cannot be performed, and skips the dwell', async () => {
+    setupRecast(env.fakeTest, { clickSettleMs: 0, hoverDwellMs: 300 })
     const sink: { clickOptions?: unknown } = {}
     const loc = makeLocator({ x: 0, y: 0, width: 10, height: 10 }, env.calls, sink)
     ;(loc as unknown as { hover: () => Promise<void> }).hover = async () => {
       throw new Error('intercepted')
     }
 
+    const t0 = Date.now()
     await click(loc)
 
     expect(env.calls).toContain('click')
+    expect(Date.now() - t0).toBeLessThan(300)
   })
 
   it('does not hover when hoverDwellMs is left at its default', async () => {


### PR DESCRIPTION
`click()` marks and presses its target immediately, and the cursor overlay is drawn in post-processing — so the recording shows a click landing on a visually unmarked element and the viewer cannot tell what was picked.

`setupRecast({ hoverDwellMs })` makes `click()` rest on the target first, letting the app paint its own hover state (highlighted row, revealed action button) into the recording.

- Off by default (`0`).
- Hover is best effort — an unhoverable target still goes through the normal `locator.click()` actionability path.
- The marker is written *after* the dwell: `resolveClickMarkers()` only pairs a marker with a click inside a short window, and an unpaired marker renders a second click.

Tests: `tests/unit/helpers/click.test.ts` covers dwell on/off, hover failure, and marker ordering.
