### PR TITLE
fix(voiceover): stop captions drifting ahead of the narration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ reports/
 .npmrc
 /.idea
 /.venv
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **Captions drifted ahead of the narration, further with every cue** — gap silence and pads are MP3s that always come out longer than requested, and narration holds rounded to the nearest frame, while the caption timeline advanced by the requested values. On a 55-cue screencast: 71ms early at the first cue, 3.37s at the last. Now +1ms and +38ms, bounded.
+
+### Behavior changes
+
+- **A narration hold can be up to one frame longer** — it rounds up instead of to the nearest frame, so it always covers its audio.
+
 ## 0.20.0 (2026-08-24)
 
 ### Features

--- a/src/voiceover/frame-align.ts
+++ b/src/voiceover/frame-align.ts
@@ -63,3 +63,21 @@ export function alignFreezeToFrame(
   const quantisedDuration = Math.round(rawDuration / per) * per + 0 // normalize -0 to 0
   return { atVideoMs: aligned, durationMs: quantisedDuration }
 }
+
+/**
+ * Align a hold that lets narration audio finish. Like {@link alignFreezeToFrame}
+ * but never rounds *down*: the caption timeline advances by this hold, so a
+ * short one leaves captions ahead of the voice and compounds across cues; the
+ * surplus is absorbed by the next gap. Non-positive/NaN fps passes through.
+ */
+export function alignNarrationHold(
+  atVideoMs: number,
+  durationMs: number,
+  fps: number,
+): { atVideoMs: number; durationMs: number } {
+  if (!(fps > 0)) return { atVideoMs, durationMs }
+  return {
+    atVideoMs: alignMsUpToFrame(atVideoMs, fps),
+    durationMs: alignMsUpToFrame(Math.max(0, durationMs), fps),
+  }
+}

--- a/src/voiceover/voiceover-processor.ts
+++ b/src/voiceover/voiceover-processor.ts
@@ -12,7 +12,7 @@ import type {
   LoudnessNormalizeConfig,
 } from '../types/voiceover.js'
 import { normalizeLoudness } from './normalize.js'
-import { alignFreezeToFrame } from './frame-align.js'
+import { alignFreezeToFrame, alignNarrationHold } from './frame-align.js'
 
 function getAudioDurationMs(filePath: string): number {
   const output = execFileSync('ffprobe', [
@@ -103,8 +103,11 @@ export async function generateVoiceover(
   // intervening visuals (clicks) don't play through before the audio ends.
   const originalStartsMs = trace.subtitles.map((s) => s.startMs)
   const originalEndsMs = trace.subtitles.map((s) => s.endMs)
-  let cursor = 0
   let timeShift = 0
+  /** Where the track really ends. Every MP3 here runs longer than requested
+   *  (24ms frames at 24kHz, encoder delay, padding), so measuring lets the next
+   *  gap absorb the excess instead of it accumulating. */
+  let audioEndMs = 0
 
   // Approach holds (cursor-glide pauses at marked clicks) are interleaved with
   // the subtitles by position: each one drained below adds its duration to
@@ -131,10 +134,19 @@ export async function generateVoiceover(
     if (subtitle.zoom?.startMs !== undefined) subtitle.zoom.startMs += timeShift
     if (subtitle.zoom?.endMs !== undefined) subtitle.zoom.endMs += timeShift
 
-    if (subtitle.startMs > cursor) {
+    // Fill from where the track really ends up to this cue's start.
+    const gapMs = subtitle.startMs - audioEndMs
+    if (gapMs > 0) {
       const silencePath = path.join(tmpDir, `silence-${subtitle.index}.mp3`)
-      generateSilence(subtitle.startMs - cursor, silencePath, silenceSampleRate, silenceChannels)
-      segmentFiles.push(silencePath)
+      generateSilence(gapMs, silencePath, silenceSampleRate, silenceChannels)
+      const silenceMs = getAudioDurationMs(silencePath)
+      // A tiny gap's smallest writable file overshoots more than skipping it.
+      if (Math.abs(silenceMs - gapMs) < gapMs) {
+        segmentFiles.push(silencePath)
+        audioEndMs += silenceMs
+      } else {
+        fs.unlinkSync(silencePath)
+      }
     }
 
     const segPath = path.join(tmpDir, `seg-${subtitle.index}.mp3`)
@@ -162,16 +174,18 @@ export async function generateVoiceover(
     // the builder clamps it and the loop shifts start/end by the same amount.
     if (audioDuration <= windowDuration) {
       segmentFiles.push(segPath)
+      audioEndMs += audioDuration
       const pad = windowDuration - audioDuration
       if (pad > 50) {
         const padPath = path.join(tmpDir, `pad-${subtitle.index}.mp3`)
         generateSilence(pad, padPath, silenceSampleRate, silenceChannels)
         segmentFiles.push(padPath)
+        audioEndMs += getAudioDurationMs(padPath)
       }
-      cursor = subtitle.endMs
     } else {
       const overflow = audioDuration - windowDuration
       segmentFiles.push(segPath)
+      audioEndMs += audioDuration
       subtitle.endMs = subtitle.startMs + audioDuration
       // Freeze the video on the last frame of this segment's window so the
       // narration finishes before the next visual action starts. Hold at the
@@ -182,13 +196,13 @@ export async function generateVoiceover(
       // before; the renderer's end-of-video tpad handles its overflow instead.
       const nextOriginalStartMs = originalStartsMs[si + 1]
       if (nextOriginalStartMs !== undefined) {
-        const aligned = alignFreezeToFrame(originalEndsMs[si]!, overflow, outputFps)
+        // Rounds up: a short hold leaves captions ahead of the voice.
+        const aligned = alignNarrationHold(originalEndsMs[si]!, overflow, outputFps)
         freezes.push(aligned)
         timeShift += aligned.durationMs
       } else {
         timeShift += overflow
       }
-      cursor = subtitle.endMs
     }
 
     entries.push({

--- a/tests/unit/voiceover/caption-audio-drift.test.ts
+++ b/tests/unit/voiceover/caption-audio-drift.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as crypto from 'node:crypto'
+import { generateVoiceover } from '../../../src/voiceover/voiceover-processor'
+import type { TtsProvider } from '../../../src/types/voiceover'
+import type { SubtitledTrace } from '../../../src/types/subtitle'
+
+/**
+ * The narration track is a concatenation of MP3 files, but cue times were
+ * advanced by the durations we *asked* for. Every generated file is longer than
+ * that: MPEG-2 frames at 24kHz quantise to 24ms, libmp3lame adds encoder delay
+ * and padding, and the `Math.max(0.01, …)` clamp gives even a 1ms gap a ~72ms
+ * file. The excess used to accumulate over every cue, so captions ran further
+ * and further ahead of the voice — on a real 55-cue screencast, 71ms of drift
+ * at the first cue and 3370ms by the last.
+ *
+ * The fix is that each gap is measured against where the audio actually ends,
+ * so one file's excess is absorbed by the next gap instead of compounding.
+ * These tests pin that: drift must stay bounded, and must not grow with cue
+ * count.
+ */
+
+const SAMPLE_RATE = 24_000
+const CHANNELS = 1
+const SPEECH_MS = 1000
+const FPS = 25
+/** Cue windows far shorter than the audio, so every cue takes the overflow
+ *  path and leaves a small gap behind — the shape that produced the drift. */
+const WINDOW_MS = 100
+const GAP_MS = 10
+
+let TMP_ROOT: string
+let SPEECH_MP3: Buffer
+
+function durationMs(file: string): number {
+  return Number(execFileSync('ffprobe', [
+    '-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', file,
+  ]).toString().trim()) * 1000
+}
+
+/** A provider handing back a fixed-length clip in the TTS format. */
+function fixedLengthProvider(): TtsProvider {
+  return {
+    name: 'fixed-length',
+    async synthesize(texts: string[], options) {
+      const dir = options?.workDir ?? TMP_ROOT
+      fs.mkdirSync(dir, { recursive: true })
+      return texts.map(() => {
+        const filePath = path.join(dir, `tts-${crypto.randomUUID()}.mp3`)
+        fs.writeFileSync(filePath, SPEECH_MP3)
+        return {
+          path: filePath,
+          durationMs: SPEECH_MS,
+          format: { sampleRate: SAMPLE_RATE, channels: CHANNELS, codec: 'mp3' },
+        }
+      })
+    },
+    async isAvailable() { return true },
+    async dispose() {},
+  }
+}
+
+function makeTrace(cueCount: number): SubtitledTrace {
+  const subtitles = Array.from({ length: cueCount }, (_, k) => ({
+    index: k + 1,
+    startMs: k * (WINDOW_MS + GAP_MS),
+    endMs: k * (WINDOW_MS + GAP_MS) + WINDOW_MS,
+    text: `line ${k + 1}`,
+    ttsText: undefined as string | undefined,
+  }))
+  return { subtitles } as unknown as SubtitledTrace
+}
+
+/**
+ * Where each cue's speech actually begins in the assembled track, measured the
+ * way the track is built: cumulative real duration of the concat list.
+ */
+function measuredSegmentStarts(tmpDir: string): Map<number, number> {
+  const files = fs.readFileSync(path.join(tmpDir, 'concat.txt'), 'utf8')
+    .split('\n').filter((l) => l.trim() !== '')
+    .map((l) => /^file '(.+)'$/.exec(l)![1]!)
+
+  const starts = new Map<number, number>()
+  let pos = 0
+  for (const file of files) {
+    const seg = /^seg-(\d+)\.mp3$/.exec(file)
+    if (seg) starts.set(Number(seg[1]), pos)
+    pos += durationMs(path.join(tmpDir, file))
+  }
+  return starts
+}
+
+/** Signed caption-minus-audio offset per cue; negative = caption is early. */
+async function driftPerCue(cueCount: number, label: string): Promise<number[]> {
+  const tmpDir = path.join(TMP_ROOT, label)
+  fs.mkdirSync(tmpDir, { recursive: true })
+  const trace = makeTrace(cueCount)
+  await generateVoiceover(trace, fixedLengthProvider(), tmpDir, undefined, [], FPS)
+
+  const starts = measuredSegmentStarts(tmpDir)
+  return trace.subtitles.map((s) => {
+    const audioStart = starts.get(s.index)
+    if (audioStart === undefined) throw new Error(`no audio for cue ${s.index}`)
+    return s.startMs - audioStart
+  })
+}
+
+describe('captions stay aligned with the narration track', () => {
+  beforeAll(() => {
+    TMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'recast-caption-drift-'))
+    const speech = path.join(TMP_ROOT, 'speech.mp3')
+    execFileSync('ffmpeg', [
+      '-y', '-v', 'error', '-f', 'lavfi',
+      '-i', `sine=frequency=440:sample_rate=${SAMPLE_RATE}:duration=${SPEECH_MS / 1000}`,
+      '-ac', String(CHANNELS), '-c:a', 'libmp3lame', '-q:a', '9', speech,
+    ], { stdio: 'pipe' })
+    SPEECH_MP3 = fs.readFileSync(speech)
+  })
+
+  afterAll(() => {
+    fs.rmSync(TMP_ROOT, { recursive: true, force: true })
+  })
+
+  it('keeps every cue within a frame or two of its audio', async () => {
+    const drift = await driftPerCue(30, 'bounded')
+    const worst = Math.max(...drift.map(Math.abs))
+    expect(
+      worst,
+      `worst drift ${worst.toFixed(0)}ms across 30 cues; per-cue drift: `
+      + drift.map((d) => d.toFixed(0)).join(', '),
+    ).toBeLessThan(100)
+  })
+
+  it('does not accumulate drift as cues go on', async () => {
+    // The signature of the bug: the last cue drifts ~N times the first.
+    const drift = await driftPerCue(30, 'accumulation')
+    const firstFive = Math.max(...drift.slice(0, 5).map(Math.abs))
+    const lastFive = Math.max(...drift.slice(-5).map(Math.abs))
+    expect(
+      lastFive,
+      `drift grew from ${firstFive.toFixed(0)}ms at the start to `
+      + `${lastFive.toFixed(0)}ms at the end`,
+    ).toBeLessThan(firstFive + 50)
+  })
+
+  it('holds alignment at 4x the cue count', async () => {
+    // Same bound at 120 cues as at 30 — the error must not scale with length.
+    const drift = await driftPerCue(120, 'long')
+    const worst = Math.max(...drift.map(Math.abs))
+    expect(worst, `worst drift ${worst.toFixed(0)}ms across 120 cues`).toBeLessThan(100)
+  })
+}, 300_000)

--- a/tests/unit/voiceover/frame-align.test.ts
+++ b/tests/unit/voiceover/frame-align.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { msPerFrame, alignMsUpToFrame, alignFreezeToFrame } from '../../../src/voiceover/frame-align'
+import {
+  msPerFrame,
+  alignMsUpToFrame,
+  alignFreezeToFrame,
+  alignNarrationHold,
+} from '../../../src/voiceover/frame-align'
 
 describe('msPerFrame', () => {
   it('converts a frame rate to milliseconds per frame', () => {
@@ -82,6 +87,58 @@ describe('alignFreezeToFrame', () => {
   it('returns inputs unchanged for a NaN or missing frame rate', () => {
     expect(alignFreezeToFrame(100, 500, NaN)).toEqual({ atVideoMs: 100, durationMs: 500 })
     expect(alignFreezeToFrame(100, 500, undefined as unknown as number)).toEqual({
+      atVideoMs: 100,
+      durationMs: 500,
+    })
+  })
+})
+
+describe('alignNarrationHold', () => {
+  it('never returns a hold shorter than the audio it must cover', () => {
+    // alignFreezeToFrame rounds to the nearest frame and subtracts the start
+    // shift, so it can come back short — which is what let captions creep
+    // ahead of the voice. This must only ever round up.
+    for (const at of [0, 7, 33, 100, 7025]) {
+      for (const dur of [0, 1, 5, 39, 40, 41, 956, 1000]) {
+        const r = alignNarrationHold(at, dur, 25)
+        expect(r.durationMs, `hold for ${dur}ms at ${at}ms`).toBeGreaterThanOrEqual(dur)
+      }
+    }
+  })
+
+  it('overshoots by less than a whole frame', () => {
+    for (const dur of [1, 5, 39, 41, 956, 1000]) {
+      expect(alignNarrationHold(0, dur, 25).durationMs - dur).toBeLessThan(40)
+    }
+  })
+
+  it('puts both endpoints on frame boundaries', () => {
+    for (const at of [0, 7, 33, 100, 7025]) {
+      const r = alignNarrationHold(at, 956, 25)
+      expect(r.atVideoMs % 40).toBe(0)
+      expect(r.durationMs % 40).toBe(0)
+      expect((r.atVideoMs + r.durationMs) % 40).toBe(0)
+    }
+  })
+
+  it('leaves an already-aligned hold untouched', () => {
+    expect(alignNarrationHold(120, 480, 25)).toEqual({ atVideoMs: 120, durationMs: 480 })
+  })
+
+  it('never moves the hold position backwards', () => {
+    for (const at of [0, 1, 39, 40, 41, 7025]) {
+      expect(alignNarrationHold(at, 100, 25).atVideoMs).toBeGreaterThanOrEqual(at)
+    }
+  })
+
+  it('clamps a negative duration to zero', () => {
+    expect(alignNarrationHold(120, -5, 25).durationMs).toBe(0)
+  })
+
+  it('returns inputs unchanged for a non-positive, NaN, or missing frame rate', () => {
+    expect(alignNarrationHold(100, 500, 0)).toEqual({ atVideoMs: 100, durationMs: 500 })
+    expect(alignNarrationHold(100, 500, NaN)).toEqual({ atVideoMs: 100, durationMs: 500 })
+    expect(alignNarrationHold(100, 500, undefined as unknown as number)).toEqual({
       atVideoMs: 100,
       durationMs: 500,
     })


### PR DESCRIPTION
Captions ran ahead of the narration and the error compounded across a run — 71 ms early at the first cue, 3.37 s at the last, on a 55-cue screencast. Two independent causes, neither reconciled:

- **Gap silence and pads are measured, not assumed.** They are MP3s concatenated by stream copy, and every one comes out longer than requested (24 ms frame quantisation at 24 kHz, encoder delay, padding — even a 1 ms gap yields ~72 ms), while the write cursor advanced by the *requested* values. Gaps are now measured against where the track really ends, so one file's excess is absorbed by the next gap.
- **Narration holds round up.** They rounded to the *nearest* frame, so a hold could come back shorter than the overflow it exists for. New `alignNarrationHold()` rounds up; `alignFreezeToFrame()` is untouched, so cursor-approach holds and the click/cursor overlay shifts keep their semantics.

Behaviour change: a narration hold can be up to one frame longer, and the sub-frame surplus is silence the next gap absorbs.

Result on the same screencast: +1 ms at the first cue, +38 ms at the last — bounded, no longer growing with cue count. Tests: drift bounds at 30 and 120 cues, plus `alignNarrationHold` rounding guarantees.

Also adds `__pycache__/` to `.gitignore` — the Qwen sidecar and the Python fixture leave bytecode caches in the tree.
