### PR TITLE
perf(render): seek to each voiceover freeze slice instead of decoding to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- **Voiceover freeze slicing no longer re-decodes the video for every slice** — slices seek with `-ss` instead of `trim=start_frame`, which decoded from frame 0 each time (O(N²) for N slices). Cuts stay frame-exact. On a 160-slice screencast the stage dropped from 551s to 125s.
+
 ## 0.20.0 (2026-08-24)
 
 ### Features

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -668,14 +668,25 @@ function applyVoiceoverFreezes(
     const seg = segments[i]!
     const segPath = path.join(tmpDir, `vo-freeze-seg-${i}.mp4`)
 
-    // Slice by frame index, not timestamp: `trim` counts decoded frames, so the
-    // boundary frame lands with the cue that owns it instead of wherever an
-    // input seek's timestamp rounding puts it. No `-ss` — the trim filter already
-    // applies the offset, and an input seek would double-apply it.
-    const trim = seg.endFrame !== null
-      ? `trim=start_frame=${seg.startFrame}:end_frame=${seg.endFrame}`
-      : `trim=start_frame=${seg.startFrame}`
-    const filters = [trim, 'setpts=PTS-STARTPTS']
+    // Seek to the slice instead of decoding up to it: `trim=start_frame` alone
+    // decodes every preceding frame, so N slices cost O(N^2) decodes.
+    //
+    // Aim half a frame early. `-ss` before `-i` is an accurate seek and yields
+    // the first frame with PTS >= the request, so asking for exactly
+    // startFrame/fps skips to startFrame+1 whenever the container timebase
+    // rounds that PTS a hair low; half a frame is unambiguous either way.
+    const seekArgs = seg.startFrame > 0
+      ? ['-ss', ((seg.startFrame - 0.5) / fps).toFixed(6)]
+      : []
+
+    // Length stays in frames, counted from the seek point, so the boundary
+    // frame lands with the cue that owns it rather than wherever timestamp
+    // rounding puts it.
+    const filters: string[] = []
+    if (seg.endFrame !== null) {
+      filters.push(`trim=end_frame=${seg.endFrame - seg.startFrame}`)
+    }
+    filters.push('setpts=PTS-STARTPTS')
 
     const pad: string[] = []
     if (seg.startHoldFrames > 0) {
@@ -687,7 +698,7 @@ function applyVoiceoverFreezes(
     if (pad.length > 0) filters.push(`tpad=${pad.join(':')}`)
 
     ffmpeg([
-      '-y', '-i', videoPath,
+      '-y', ...seekArgs, '-i', videoPath,
       '-vf', filters.join(','),
       '-c:v', 'libx264', '-preset', 'fast', '-crf', '18', '-an',
       segPath,

--- a/tests/unit/render/freeze-slice-seek.test.ts
+++ b/tests/unit/render/freeze-slice-seek.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+/**
+ * applyVoiceoverFreezes() seeks to each slice with `-ss` instead of letting
+ * `trim=start_frame` decode every preceding frame. Without the seek, N slices
+ * cost O(N²) decodes: a real 160-slice screencast spent 9 minutes in this
+ * stage, and one 31-frame slice near the end took 6.9s.
+ *
+ * The seek must not move the cut. These cases pin the equivalence the renderer
+ * relies on — a half-frame-early `-ss` plus a relative `trim=end_frame` yields
+ * byte-identical frames to the absolute `trim=start_frame:end_frame` it
+ * replaced, including across keyframe boundaries.
+ */
+
+const FPS = 25
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'recast-freeze-seek-test-'))
+const SRC = path.join(TMP_DIR, 'src.mp4')
+
+/** Per-frame checksums of a decoded slice, so an off-by-one cut is visible. */
+function frameHashes(args: string[]): string[] {
+  const out = path.join(TMP_DIR, 'hashes.framemd5')
+  execFileSync('ffmpeg', [
+    '-y', '-v', 'error', ...args,
+    '-an', '-pix_fmt', 'yuv420p', '-f', 'framemd5', out,
+  ], { stdio: 'pipe' })
+  return fs.readFileSync(out, 'utf8')
+    .split('\n')
+    .filter((line) => line !== '' && !line.startsWith('#'))
+    .map((line) => line.split(',').pop()!.trim())
+}
+
+/** The slicing this replaced: absolute frame indices, full decode from 0. */
+function trimOnly(startFrame: number, endFrame: number | null): string[] {
+  const trim = endFrame !== null
+    ? `trim=start_frame=${startFrame}:end_frame=${endFrame}`
+    : `trim=start_frame=${startFrame}`
+  return frameHashes(['-i', SRC, '-vf', `${trim},setpts=PTS-STARTPTS`])
+}
+
+/** The slicing the renderer now emits: seek + frame-counted length. */
+function seekAndTrim(startFrame: number, endFrame: number | null): string[] {
+  const seekArgs = startFrame > 0
+    ? ['-ss', ((startFrame - 0.5) / FPS).toFixed(6)]
+    : []
+  const filters = endFrame !== null
+    ? [`trim=end_frame=${endFrame - startFrame}`, 'setpts=PTS-STARTPTS']
+    : ['setpts=PTS-STARTPTS']
+  return frameHashes([...seekArgs, '-i', SRC, '-vf', filters.join(',')])
+}
+
+describe('freeze slicing seeks without moving the cut', () => {
+  beforeAll(() => {
+    // testsrc gives every frame distinct content, so a cut that slips by one
+    // frame changes the checksums instead of hiding in identical stills.
+    // 1000 frames spans several x264 keyframe intervals.
+    execFileSync('ffmpeg', [
+      '-y', '-f', 'lavfi', '-i', `testsrc=s=320x240:r=${FPS}:d=40`,
+      '-c:v', 'libx264', '-preset', 'ultrafast', '-pix_fmt', 'yuv420p', SRC,
+    ], { stdio: 'pipe' })
+  })
+
+  afterAll(() => {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true })
+  })
+
+  it.each([
+    // A leading slice has no seek to apply at all.
+    { startFrame: 0, endFrame: 1, name: 'single opening frame' },
+    { startFrame: 0, endFrame: 37, name: 'from the first frame' },
+    // Every keyframe-relative position: the seek decodes from the preceding
+    // keyframe, so landing exactly on one, just before, and just after it are
+    // the cases where an accurate seek could round to the wrong frame.
+    { startFrame: 249, endFrame: 260, name: 'just before a keyframe' },
+    { startFrame: 250, endFrame: 281, name: 'exactly on a keyframe' },
+    { startFrame: 251, endFrame: 252, name: 'just after a keyframe' },
+    { startFrame: 613, endFrame: 681, name: 'mid-GOP' },
+    { startFrame: 999, endFrame: 1000, name: 'final frame' },
+  ])('matches trim-only slicing $name', ({ startFrame, endFrame }) => {
+    const expected = trimOnly(startFrame, endFrame)
+    expect(expected).toHaveLength(endFrame - startFrame)
+    expect(seekAndTrim(startFrame, endFrame)).toEqual(expected)
+  })
+
+  it('matches trim-only slicing for an open-ended tail slice', () => {
+    const expected = trimOnly(940, null)
+    expect(expected).toHaveLength(60)
+    expect(seekAndTrim(940, null)).toEqual(expected)
+  })
+
+  it('reassembles the whole video when contiguous slices are concatenated', () => {
+    // The renderer concatenates the slices back together, so the cuts must
+    // partition the frames with no gap, overlap, or duplicated boundary frame.
+    const cuts = [0, 1, 249, 250, 251, 613, 940, 1000]
+    const sliced = cuts.slice(0, -1).flatMap((start, i) =>
+      seekAndTrim(start, cuts[i + 1]!),
+    )
+    expect(sliced).toEqual(trimOnly(0, 1000))
+  })
+}, 180_000)


### PR DESCRIPTION
Each voiceover freeze slice was cut with `trim=start_frame=N` and no input seek, so ffmpeg decoded from frame 0 every time: N slices cost O(N²) decodes. A 160-slice screencast spent 9.2 minutes in this stage, and a 31-frame slice near the end took 6.9 s where seeking to it takes 0.3 s.

Slices now seek with `-ss`, aimed half a frame early so an accurate seek cannot round past the wanted frame, and `trim` carries only the length.

- Stage time: **551 s → 125 s**.
- Cuts stay frame-exact: replaying all 160 real slice boundaries against a per-frame checksum (`framemd5`) reference produced byte-identical frames, including across keyframe boundaries.
