### PR TITLE
fix(highlight): composite after freezes and keep marks exclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **Highlights were held for the length of a narration freeze, and could overlap** — the overlay was composited before voiceover freezes, so a mark caught by a narration hold stayed frozen there for the whole spoken line, and nothing kept two marks apart. Highlights now composite after the freezes, keep their configured duration, and end when the next mark appears.
+
 ## 0.20.0 (2026-08-24)
 
 ### Features

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -539,6 +539,9 @@ export class PipelineExecutor {
             }
           }
           if (traceHighlights.length > 0) {
+            // Overlap is resolved in the renderer, on the freeze-extended
+            // timeline — the only clock on which "until the next mark" is a
+            // real distance.
             state.highlightEvents = traceHighlights
             state.highlightConfig = hlDefaults
             console.log(`  highlight: ${traceHighlights.length} from trace`)

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -68,6 +68,7 @@ type PipelineState = {
   interpolateConfig?: import('../types/interpolate.js').InterpolateConfig
   highlightEvents?: HighlightEvent[]
   highlightConfig?: ResolvedTextHighlightConfig
+  highlightsOnFreezeClock?: boolean
   introConfig?: IntroConfig
   outroConfig?: OutroConfig
   backgroundMusicConfig?: ResolvedBackgroundMusicConfig
@@ -156,6 +157,7 @@ export class PipelineExecutor {
       interpolateConfig: state.interpolateConfig,
       highlightEvents: state.highlightEvents,
       highlightConfig: state.highlightConfig,
+      highlightsOnFreezeClock: state.highlightsOnFreezeClock,
     }
 
     // Render final video
@@ -937,6 +939,10 @@ export class PipelineExecutor {
 
           state.highlightEvents = filtered
           state.highlightConfig = hlConfig
+          // These times come from the subtitles, which voiceover() rewrites
+          // onto the freeze-extended clock — so after it, they are already
+          // shifted and the renderer must not shift them again.
+          state.highlightsOnFreezeClock = state.voiceovered !== undefined
           console.log(`  textHighlight: ${filtered.length} highlight(s) from report`)
           for (const he of filtered) {
             console.log(`    highlight: (${he.x}, ${he.y}) ${he.width}x${he.height} @ ${he.videoTimeMs}ms [${he.color}]`)

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -15,6 +15,7 @@ import { buildZoomFilter, stepZoomsToKeyframes, type ZoomExprConfig } from './zo
 import { generateRippleClip } from '../click-effect/ripple-generator.js'
 import type { HighlightEvent } from '../types/text-highlight.js'
 import { generateHighlightClip } from '../text-highlight/highlight-generator.js'
+import { makeHighlightsExclusive, shiftHighlightsForFreezes } from '../text-highlight/exclusivity.js'
 import { writeDefaultClickSound } from '../click-effect/defaults.js'
 import { generateClickSoundTrack, getAudioDurationMs as getClickAudioDurationMs } from '../click-effect/sound-track.js'
 import { writeSrt } from '../subtitles/srt-writer.js'
@@ -815,18 +816,6 @@ export function renderVideo(
     videoInput = interpolatedPath
   }
 
-  // Phase 3.3: Apply text highlight overlays (pre-freeze; highlights freeze
-  // with the held frame, which is acceptable since their duration is
-  // configured independently).
-  if (trace.highlightEvents && trace.highlightEvents.length > 0) {
-    videoInput = renderWithHighlights(
-      videoInput,
-      trace.highlightEvents,
-      trace.metadata.viewport,
-      tmpDir,
-    )
-  }
-
   // Phase 3.4: Voiceover-driven freezes. If a narration's audio is longer
   // than its visual window, the voiceover stage records "freeze" points so
   // the video holds the current frame until the audio finishes. We apply
@@ -869,6 +858,21 @@ export function renderVideo(
           shiftForFreezes(kf.videoTimeSec * 1000, allFreezes) / 1000
       }
     }
+    if (trace.highlightEvents) {
+      trace.highlightEvents = shiftHighlightsForFreezes(trace.highlightEvents, allFreezes)
+    }
+  }
+
+  // Phase 3.44: Highlights, on the freeze-extended timeline like the cursor and
+  // click overlays. Compositing them before the freezes instead held whichever
+  // mark was on screen for the whole spoken line.
+  if (trace.highlightEvents && trace.highlightEvents.length > 0) {
+    videoInput = renderWithHighlights(
+      videoInput,
+      makeHighlightsExclusive(trace.highlightEvents),
+      trace.metadata.viewport,
+      tmpDir,
+    )
   }
 
   // Phase 3.45: Apply cursor overlay on the freeze-extended timeline. The

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -88,6 +88,8 @@ export interface RenderableTrace extends ParsedTrace {
   zoomConfig?: { transitionMs?: number; easing?: import('../types/easing.js').EasingSpec; containInCue?: boolean }
   interpolateConfig?: import('../types/interpolate.js').InterpolateConfig
   highlightEvents?: import('../types/text-highlight.js').HighlightEvent[]
+  /** Highlight times are already on the freeze-extended clock. */
+  highlightsOnFreezeClock?: boolean
   highlightConfig?: import('../text-highlight/defaults.js').ResolvedTextHighlightConfig
 }
 
@@ -858,7 +860,7 @@ export function renderVideo(
           shiftForFreezes(kf.videoTimeSec * 1000, allFreezes) / 1000
       }
     }
-    if (trace.highlightEvents) {
+    if (trace.highlightEvents && !trace.highlightsOnFreezeClock) {
       trace.highlightEvents = shiftHighlightsForFreezes(trace.highlightEvents, allFreezes)
     }
   }

--- a/src/text-highlight/exclusivity.ts
+++ b/src/text-highlight/exclusivity.ts
@@ -7,8 +7,8 @@ import type { HighlightEvent } from '../types/text-highlight.js'
  * speed-mapped output clock, so compressing idle time pulls marks closer
  * together than their durations. A clamped mark keeps whatever window is left:
  * `fadeOut` (at most half of it, so the mark is solid before it fades) and
- * `swipeDuration` shrink to fit. Marks sharing a timestamp leave no window at
- * all, and the earlier one is dropped.
+ * `swipeDuration` shrink to fit. A mark left with no window at all — two on
+ * the same timestamp, or an empty event — is dropped.
  */
 export function makeHighlightsExclusive(
   events: ReadonlyArray<HighlightEvent>,
@@ -19,17 +19,23 @@ export function makeHighlightsExclusive(
   for (let i = 0; i < sorted.length; i++) {
     const current = sorted[i]!
     const next = sorted[i + 1]
-    if (next === undefined || current.endTimeMs <= next.videoTimeMs) {
+    const endTimeMs = next === undefined
+      ? current.endTimeMs
+      : Math.min(current.endTimeMs, next.videoTimeMs)
+    const window = endTimeMs - current.videoTimeMs
+
+    // No window at all: two marks on the same timestamp, or an empty event.
+    // Either way there is nothing to render — ffmpeg rejects a zero-length clip.
+    if (window <= 0) continue
+
+    if (endTimeMs === current.endTimeMs) {
       exclusive.push(current)
       continue
     }
 
-    const window = next.videoTimeMs - current.videoTimeMs
-    if (window <= 0) continue
-
     exclusive.push({
       ...current,
-      endTimeMs: next.videoTimeMs,
+      endTimeMs,
       fadeOut: Math.min(current.fadeOut, Math.floor(window / 2)),
       swipeDuration: Math.min(current.swipeDuration, window),
     })

--- a/src/text-highlight/exclusivity.ts
+++ b/src/text-highlight/exclusivity.ts
@@ -7,8 +7,8 @@ import type { HighlightEvent } from '../types/text-highlight.js'
  * speed-mapped output clock, so compressing idle time pulls marks closer
  * together than their durations. Every mark is then fitted to the window it
  * has — its own, or the one the next mark leaves it: `fadeOut` takes at most
- * half of it, so the mark is solid before it fades, and `swipeDuration` shrinks
- * to fit. A mark with no window at all — two on the same timestamp, an event
+ * half of it, so the mark is solid before it fades, and `swipeDuration` fits in
+ * the solid part, so the rectangle is fully revealed before the fade starts. A mark with no window at all — two on the same timestamp, an event
  * already clamped to nothing — is dropped.
  *
  * Fitting applies to every mark, not just clamped ones: the pipeline clamps a
@@ -33,11 +33,14 @@ export function makeHighlightsExclusive(
     // Either way there is nothing to render — ffmpeg rejects a zero-length clip.
     if (window <= 0) continue
 
+    // The swipe has to finish before the fade starts, so it gets the solid
+    // part of the window, not all of it.
+    const fadeOut = Math.min(current.fadeOut, Math.floor(window / 2))
     exclusive.push({
       ...current,
       endTimeMs,
-      fadeOut: Math.min(current.fadeOut, Math.floor(window / 2)),
-      swipeDuration: Math.min(current.swipeDuration, window),
+      fadeOut,
+      swipeDuration: Math.min(current.swipeDuration, window - fadeOut),
     })
   }
 

--- a/src/text-highlight/exclusivity.ts
+++ b/src/text-highlight/exclusivity.ts
@@ -1,0 +1,60 @@
+import type { HighlightEvent } from '../types/text-highlight.js'
+
+/** Shortest window a clamped highlight may keep, in ms. */
+export const MIN_HIGHLIGHT_WINDOW_MS = 200
+
+/**
+ * End each highlight when the next one begins, so only one is ever on screen.
+ *
+ * Durations are nominal wall-clock values while `videoTimeMs` is on the
+ * speed-mapped output clock, so compressing idle time pulls marks closer
+ * together than their durations. Shortens `endTimeMs` (and `fadeOut`, which
+ * the renderer subtracts from the clip length) but never below
+ * `MIN_HIGHLIGHT_WINDOW_MS`, so a crowded mark still flashes visibly.
+ */
+export function makeHighlightsExclusive(
+  events: ReadonlyArray<HighlightEvent>,
+): HighlightEvent[] {
+  const sorted = [...events].sort((a, b) => a.videoTimeMs - b.videoTimeMs)
+
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const current = sorted[i]!
+    const next = sorted[i + 1]!
+    if (current.endTimeMs <= next.videoTimeMs) continue
+
+    const clampedEnd = Math.max(
+      next.videoTimeMs,
+      current.videoTimeMs + MIN_HIGHLIGHT_WINDOW_MS,
+    )
+    const window = clampedEnd - current.videoTimeMs
+    // The renderer builds the clip as (end - start - fadeOut), so a fade longer
+    // than the shortened window would produce a non-positive duration.
+    const fadeOut = Math.min(current.fadeOut, Math.max(0, window - MIN_HIGHLIGHT_WINDOW_MS))
+    sorted[i] = { ...current, endTimeMs: clampedEnd, fadeOut }
+  }
+
+  return sorted
+}
+
+/**
+ * Move highlights onto the freeze-extended timeline, keeping each one's
+ * configured duration.
+ *
+ * Only freezes *before* a mark shift it. Shifting its end independently would
+ * also add the freezes inside its window, holding it on the frozen frame for
+ * the whole spoken line.
+ */
+export function shiftHighlightsForFreezes(
+  events: ReadonlyArray<HighlightEvent>,
+  freezes: ReadonlyArray<{ atVideoMs: number; durationMs: number }>,
+): HighlightEvent[] {
+  return events.map((event) => {
+    const durationMs = event.endTimeMs - event.videoTimeMs
+    let shift = 0
+    for (const freeze of freezes) {
+      if (freeze.atVideoMs <= event.videoTimeMs) shift += freeze.durationMs
+    }
+    const videoTimeMs = event.videoTimeMs + shift
+    return { ...event, videoTimeMs, endTimeMs: videoTimeMs + durationMs }
+  })
+}

--- a/src/text-highlight/exclusivity.ts
+++ b/src/text-highlight/exclusivity.ts
@@ -1,39 +1,41 @@
 import type { HighlightEvent } from '../types/text-highlight.js'
 
-/** Shortest window a clamped highlight may keep, in ms. */
-export const MIN_HIGHLIGHT_WINDOW_MS = 200
-
 /**
  * End each highlight when the next one begins, so only one is ever on screen.
  *
  * Durations are nominal wall-clock values while `videoTimeMs` is on the
  * speed-mapped output clock, so compressing idle time pulls marks closer
- * together than their durations. Shortens `endTimeMs` (and `fadeOut`, which
- * the renderer subtracts from the clip length) but never below
- * `MIN_HIGHLIGHT_WINDOW_MS`, so a crowded mark still flashes visibly.
+ * together than their durations. A clamped mark keeps whatever window is left:
+ * `fadeOut` (at most half of it, so the mark is solid before it fades) and
+ * `swipeDuration` shrink to fit. Marks sharing a timestamp leave no window at
+ * all, and the earlier one is dropped.
  */
 export function makeHighlightsExclusive(
   events: ReadonlyArray<HighlightEvent>,
 ): HighlightEvent[] {
   const sorted = [...events].sort((a, b) => a.videoTimeMs - b.videoTimeMs)
+  const exclusive: HighlightEvent[] = []
 
-  for (let i = 0; i < sorted.length - 1; i++) {
+  for (let i = 0; i < sorted.length; i++) {
     const current = sorted[i]!
-    const next = sorted[i + 1]!
-    if (current.endTimeMs <= next.videoTimeMs) continue
+    const next = sorted[i + 1]
+    if (next === undefined || current.endTimeMs <= next.videoTimeMs) {
+      exclusive.push(current)
+      continue
+    }
 
-    const clampedEnd = Math.max(
-      next.videoTimeMs,
-      current.videoTimeMs + MIN_HIGHLIGHT_WINDOW_MS,
-    )
-    const window = clampedEnd - current.videoTimeMs
-    // The renderer builds the clip as (end - start - fadeOut), so a fade longer
-    // than the shortened window would produce a non-positive duration.
-    const fadeOut = Math.min(current.fadeOut, Math.max(0, window - MIN_HIGHLIGHT_WINDOW_MS))
-    sorted[i] = { ...current, endTimeMs: clampedEnd, fadeOut }
+    const window = next.videoTimeMs - current.videoTimeMs
+    if (window <= 0) continue
+
+    exclusive.push({
+      ...current,
+      endTimeMs: next.videoTimeMs,
+      fadeOut: Math.min(current.fadeOut, Math.floor(window / 2)),
+      swipeDuration: Math.min(current.swipeDuration, window),
+    })
   }
 
-  return sorted
+  return exclusive
 }
 
 /**

--- a/src/text-highlight/exclusivity.ts
+++ b/src/text-highlight/exclusivity.ts
@@ -5,10 +5,15 @@ import type { HighlightEvent } from '../types/text-highlight.js'
  *
  * Durations are nominal wall-clock values while `videoTimeMs` is on the
  * speed-mapped output clock, so compressing idle time pulls marks closer
- * together than their durations. A clamped mark keeps whatever window is left:
- * `fadeOut` (at most half of it, so the mark is solid before it fades) and
- * `swipeDuration` shrink to fit. A mark left with no window at all — two on
- * the same timestamp, or an empty event — is dropped.
+ * together than their durations. Every mark is then fitted to the window it
+ * has — its own, or the one the next mark leaves it: `fadeOut` takes at most
+ * half of it, so the mark is solid before it fades, and `swipeDuration` shrinks
+ * to fit. A mark with no window at all — two on the same timestamp, an event
+ * already clamped to nothing — is dropped.
+ *
+ * Fitting applies to every mark, not just clamped ones: the pipeline clamps a
+ * highlight to its subtitle's end, which can already leave it shorter than its
+ * configured `fadeOut`, and the renderer needs a positive pre-fade duration.
  */
 export function makeHighlightsExclusive(
   events: ReadonlyArray<HighlightEvent>,
@@ -27,11 +32,6 @@ export function makeHighlightsExclusive(
     // No window at all: two marks on the same timestamp, or an empty event.
     // Either way there is nothing to render — ffmpeg rejects a zero-length clip.
     if (window <= 0) continue
-
-    if (endTimeMs === current.endTimeMs) {
-      exclusive.push(current)
-      continue
-    }
 
     exclusive.push({
       ...current,

--- a/tests/unit/highlight/exclusivity.test.ts
+++ b/tests/unit/highlight/exclusivity.test.ts
@@ -63,6 +63,17 @@ describe('makeHighlightsExclusive()', () => {
     expect(first!.fadeOut).toBe(50)
   })
 
+  it('drops an empty mark instead of emitting a zero-length clip', () => {
+    const result = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 1000 }),
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000, width: 20 }),
+      makeEvent({ videoTimeMs: 9000, endTimeMs: 9000 }),
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.width).toBe(20)
+  })
+
   it('drops a mark that shares its start with the next one', () => {
     const result = makeHighlightsExclusive([
       makeEvent({ videoTimeMs: 1000, endTimeMs: 5000, width: 10 }),

--- a/tests/unit/highlight/exclusivity.test.ts
+++ b/tests/unit/highlight/exclusivity.test.ts
@@ -49,7 +49,7 @@ describe('makeHighlightsExclusive()', () => {
     ])
 
     expect(only!.fadeOut).toBe(50)
-    expect(only!.swipeDuration).toBe(100)
+    expect(only!.swipeDuration).toBe(50)
     expect(only!.endTimeMs - only!.videoTimeMs - only!.fadeOut).toBeGreaterThan(0)
   })
 
@@ -71,8 +71,9 @@ describe('makeHighlightsExclusive()', () => {
 
     expect(first!.endTimeMs).toBe(1100)
     expect(first!.endTimeMs).toBeLessThanOrEqual(second!.videoTimeMs)
-    expect(first!.swipeDuration).toBe(100)
     expect(first!.fadeOut).toBe(50)
+    // The swipe finishes inside the solid part, before the fade begins.
+    expect(first!.swipeDuration).toBe(50)
   })
 
   it('drops an empty mark instead of emitting a zero-length clip', () => {

--- a/tests/unit/highlight/exclusivity.test.ts
+++ b/tests/unit/highlight/exclusivity.test.ts
@@ -3,7 +3,6 @@ import type { HighlightEvent } from '../../../src/types/text-highlight'
 import {
   makeHighlightsExclusive,
   shiftHighlightsForFreezes,
-  MIN_HIGHLIGHT_WINDOW_MS,
 } from '../../../src/text-highlight/exclusivity'
 
 function makeEvent(overrides: Partial<HighlightEvent>): HighlightEvent {
@@ -52,13 +51,26 @@ describe('makeHighlightsExclusive()', () => {
     expect(result[0]!.endTimeMs).toBe(3000)
   })
 
-  it('keeps a minimum visible window for back-to-back marks', () => {
-    const [first] = makeHighlightsExclusive([
-      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000 }),
-      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000 }),
+  it('shrinks a crowded mark into the gap before the next one', () => {
+    const [first, second] = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000, fadeOut: 400, swipeDuration: 300 }),
+      makeEvent({ videoTimeMs: 1100, endTimeMs: 5000 }),
     ])
 
-    expect(first!.endTimeMs).toBe(1000 + MIN_HIGHLIGHT_WINDOW_MS)
+    expect(first!.endTimeMs).toBe(1100)
+    expect(first!.endTimeMs).toBeLessThanOrEqual(second!.videoTimeMs)
+    expect(first!.swipeDuration).toBe(100)
+    expect(first!.fadeOut).toBe(50)
+  })
+
+  it('drops a mark that shares its start with the next one', () => {
+    const result = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000, width: 10 }),
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000, width: 20 }),
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.width).toBe(20)
   })
 
   it('shrinks fadeOut so the clamped window stays a positive clip length', () => {

--- a/tests/unit/highlight/exclusivity.test.ts
+++ b/tests/unit/highlight/exclusivity.test.ts
@@ -41,6 +41,18 @@ describe('makeHighlightsExclusive()', () => {
     expect(makeHighlightsExclusive(input)).toEqual(input)
   })
 
+  it('fits fadeOut to a short window even without a neighbour', () => {
+    // The pipeline clamps a highlight to its subtitle's end, so it can arrive
+    // shorter than its own fadeOut; the renderer needs end - start - fadeOut > 0.
+    const [only] = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 1100, fadeOut: 500, swipeDuration: 300 }),
+    ])
+
+    expect(only!.fadeOut).toBe(50)
+    expect(only!.swipeDuration).toBe(100)
+    expect(only!.endTimeMs - only!.videoTimeMs - only!.fadeOut).toBeGreaterThan(0)
+  })
+
   it('sorts by start time before clamping', () => {
     const result = makeHighlightsExclusive([
       makeEvent({ videoTimeMs: 3000, endTimeMs: 9000 }),

--- a/tests/unit/highlight/exclusivity.test.ts
+++ b/tests/unit/highlight/exclusivity.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import type { HighlightEvent } from '../../../src/types/text-highlight'
+import {
+  makeHighlightsExclusive,
+  shiftHighlightsForFreezes,
+  MIN_HIGHLIGHT_WINDOW_MS,
+} from '../../../src/text-highlight/exclusivity'
+
+function makeEvent(overrides: Partial<HighlightEvent>): HighlightEvent {
+  return {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 20,
+    videoTimeMs: 0,
+    endTimeMs: 2000,
+    color: '#FFEB3B',
+    opacity: 0.35,
+    swipeDuration: 300,
+    fadeOut: 0,
+    ...overrides,
+  }
+}
+
+describe('makeHighlightsExclusive()', () => {
+  it('cuts a highlight short when the next one starts before it would end', () => {
+    const [first, second] = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 0, endTimeMs: 4500 }),
+      makeEvent({ videoTimeMs: 1500, endTimeMs: 6000 }),
+    ])
+
+    expect(first!.endTimeMs).toBe(1500)
+    expect(second!.endTimeMs).toBe(6000)
+  })
+
+  it('leaves highlights that do not overlap untouched', () => {
+    const input = [
+      makeEvent({ videoTimeMs: 0, endTimeMs: 1000, fadeOut: 200 }),
+      makeEvent({ videoTimeMs: 4000, endTimeMs: 6000, fadeOut: 200 }),
+    ]
+
+    expect(makeHighlightsExclusive(input)).toEqual(input)
+  })
+
+  it('sorts by start time before clamping', () => {
+    const result = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 3000, endTimeMs: 9000 }),
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 9000 }),
+    ])
+
+    expect(result.map((e) => e.videoTimeMs)).toEqual([1000, 3000])
+    expect(result[0]!.endTimeMs).toBe(3000)
+  })
+
+  it('keeps a minimum visible window for back-to-back marks', () => {
+    const [first] = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000 }),
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 5000 }),
+    ])
+
+    expect(first!.endTimeMs).toBe(1000 + MIN_HIGHLIGHT_WINDOW_MS)
+  })
+
+  it('shrinks fadeOut so the clamped window stays a positive clip length', () => {
+    const [first] = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 0, endTimeMs: 4000, fadeOut: 500 }),
+      makeEvent({ videoTimeMs: 300, endTimeMs: 4000, fadeOut: 500 }),
+    ])
+
+    // renderer builds the clip as end - start - fadeOut; it must stay > 0
+    expect(first!.endTimeMs - first!.videoTimeMs - first!.fadeOut).toBeGreaterThan(0)
+    expect(first!.fadeOut).toBeLessThanOrEqual(500)
+  })
+
+  it('returns a new array and does not mutate its input', () => {
+    const input = [
+      makeEvent({ videoTimeMs: 0, endTimeMs: 4500 }),
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 4500 }),
+    ]
+    const snapshot = structuredClone(input)
+
+    makeHighlightsExclusive(input)
+
+    expect(input).toEqual(snapshot)
+  })
+})
+
+describe('shiftHighlightsForFreezes()', () => {
+  it('keeps the configured duration when a freeze lands inside the window', () => {
+    const [shifted] = shiftHighlightsForFreezes(
+      [makeEvent({ videoTimeMs: 1000, endTimeMs: 3000 })],
+      [{ atVideoMs: 1200, durationMs: 7000 }],
+    )
+
+    // The hold starts after the mark appears, so the mark is not pushed back —
+    // and it still lasts 2s of finished video rather than 2s + the 7s hold.
+    expect(shifted!.videoTimeMs).toBe(1000)
+    expect(shifted!.endTimeMs - shifted!.videoTimeMs).toBe(2000)
+  })
+
+  it('pushes a highlight back past the freezes that precede it', () => {
+    const [shifted] = shiftHighlightsForFreezes(
+      [makeEvent({ videoTimeMs: 5000, endTimeMs: 7000 })],
+      [{ atVideoMs: 1000, durationMs: 3000 }, { atVideoMs: 2000, durationMs: 500 }],
+    )
+
+    expect(shifted!.videoTimeMs).toBe(8500)
+    expect(shifted!.endTimeMs).toBe(10_500)
+  })
+
+  it('is a no-op without freezes and never mutates its input', () => {
+    const input = [makeEvent({ videoTimeMs: 100, endTimeMs: 900 })]
+    const snapshot = structuredClone(input)
+
+    expect(shiftHighlightsForFreezes(input, [])).toEqual(input)
+    expect(input).toEqual(snapshot)
+  })
+
+  it('cannot reintroduce an overlap between clamped neighbours', () => {
+    const clamped = makeHighlightsExclusive([
+      makeEvent({ videoTimeMs: 1000, endTimeMs: 9000 }),
+      makeEvent({ videoTimeMs: 2000, endTimeMs: 9000 }),
+    ])
+    const shifted = shiftHighlightsForFreezes(clamped, [{ atVideoMs: 1500, durationMs: 6000 }])
+
+    expect(shifted[0]!.endTimeMs).toBeLessThanOrEqual(shifted[1]!.videoTimeMs)
+  })
+})


### PR DESCRIPTION
Two defects in how highlight marks are timed:

- The highlight overlay was composited **before** voiceover freezes, so a mark on screen when a narration hold started stayed frozen there for the whole spoken line while its neighbours flashed past.
- Nothing kept two marks apart. Durations are nominal wall-clock values while `videoTimeMs` is on the speed-mapped output clock, so compressing idle time pulls marks closer together than their durations and the previous one was still up when the next swiped in.

Highlights now composite after the freezes, like the cursor and click overlays:

- Each is shifted onto the freeze-extended timeline keeping its configured duration (only freezes *before* a mark shift it).
- Each ends exactly where the next begins — a strict clamp, no minimum-window floor, since a floor is what let two marks share the screen.
- Every mark is then fitted to the window it has: `fadeOut` takes at most half of it, so the mark is solid before it fades, and `swipeDuration` shrinks so a short mark still reveals fully. This applies to unclamped marks too — the pipeline clamps a highlight to its subtitle's end, which can already leave it shorter than its own `fadeOut`.
- A mark with no window at all — two on the same timestamp, or an already-empty event — is dropped rather than sent to ffmpeg as a zero-length clip.

Highlight times from `textHighlight()` are derived from the subtitles, which `voiceover()` rewrites onto the freeze-extended clock, so the executor records which clock they were built on and the renderer skips the shift for those. Trace-marker highlights come from action timestamps and are always pre-freeze.

New `src/text-highlight/exclusivity.ts` holds the rules, unit-tested independently of ffmpeg.
