### PR TITLE
fix(cursor-overlay): render more than ~96 keyframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **Cursor overlays failed to render past ~96 keyframes** — the trajectory expression nested one `if()` per keyframe and ffmpeg's expression parser allows ~100 nesting levels (libavutil/eval.c), so a long screencast died in the cursor stage with a filter parse error. Per-keyframe branches are now combined by a balanced bisection on movement start time, so nesting is log2(keyframes); verified against ffmpeg's own evaluator at 200 keyframes.
+
 ## 0.20.0 (2026-08-24)
 
 ### Features

--- a/src/cursor-overlay/expression-builder.ts
+++ b/src/cursor-overlay/expression-builder.ts
@@ -109,10 +109,9 @@ function buildTrajectoryAxis(
   const visibleAfter = Math.max(0, config.hideAfterMs / 1000)
   const initialOffset = Math.round(INITIAL_OFFSET * scale)
   const easedProgress = progressExpression(config.easing)
-  const segments: string[] = []
+  const branches: Branch[] = []
 
-  // Later movements take priority when pointer visibility windows overlap.
-  for (let i = points.length - 1; i >= 0; i--) {
+  for (let i = 0; i < points.length; i++) {
     const point = points[i]!
     const target = point[axis]
     const previous = i === 0 ? target - initialOffset : points[i - 1]![axis]
@@ -127,16 +126,40 @@ function buildTrajectoryAxis(
       `${start}+(${target - start})*${easedProgress}\\,` +
       `${target})`
 
-    segments.push(
-      `if(between(t\\,${moveStart.toFixed(4)}\\,${(point.t + visibleAfter).toFixed(4)})\\,${segment}\\,`
-    )
+    branches.push({
+      from: moveStart,
+      expr:
+        `if(between(t\\,${moveStart.toFixed(4)}\\,${(point.t + visibleAfter).toFixed(4)})\\,${segment}\\,0)`,
+    })
   }
 
-  let expr = segments.join('')
-  expr += '0'
-  expr += ')'.repeat(segments.length)
+  return buildBranchSearch(branches, 0, branches.length - 1)
+}
 
-  return expr
+/** One keyframe's position expression, keyed by the time its movement starts. */
+interface Branch {
+  from: number
+  expr: string
+}
+
+/**
+ * Bisect on movement start times instead of chaining one `if()` per keyframe:
+ * ffmpeg's expression parser allows ~100 nesting levels (libavutil/eval.c), so
+ * a chain stopped parsing past ~96 keyframes. Nesting is now log2(keyframes).
+ *
+ * Equivalent to the chain because movement starts and window ends both grow in
+ * keyframe order: the last branch that has started is the one the chain
+ * matched first, and past its window every earlier window has closed too.
+ */
+function buildBranchSearch(branches: Branch[], lo: number, hi: number): string {
+  if (lo === hi) return branches[lo]!.expr
+
+  // Right half keeps `mid`, so coincident start times resolve to the later
+  // keyframe — the one the chain gave priority to.
+  const mid = Math.ceil((lo + hi) / 2)
+  const left = buildBranchSearch(branches, lo, mid - 1)
+  const right = buildBranchSearch(branches, mid, hi)
+  return `if(lt(t\\,${branches[mid]!.from.toFixed(4)})\\,${left}\\,${right})`
 }
 
 /**

--- a/tests/unit/cursor-overlay/expression-builder.test.ts
+++ b/tests/unit/cursor-overlay/expression-builder.test.ts
@@ -166,10 +166,12 @@ describe('buildOverlayExpressions', () => {
       srcRes,
     )
 
-    // Nested ffmpeg if() branches are evaluated from left to right.
-    expect(result.x.indexOf('2.0000\\,2.7000')).toBeLessThan(
-      result.x.indexOf('1.5000\\,2.5000'),
-    )
+    // Both windows are present, and the expression bisects on the later
+    // movement start, so t >= 2.0 resolves to the later keyframe.
+    // expression-eval.test.ts checks the resulting positions with ffmpeg.
+    expect(result.x).toContain('1.5000\\,2.5000')
+    expect(result.x).toContain('2.0000\\,2.7000')
+    expect(result.x.startsWith('if(lt(t\\,2.0000)\\,')).toBe(true)
   })
 })
 

--- a/tests/unit/cursor-overlay/expression-eval.test.ts
+++ b/tests/unit/cursor-overlay/expression-eval.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { buildOverlayExpressions } from '../../../src/cursor-overlay/expression-builder'
+import { resolveCursorOverlayConfig } from '../../../src/cursor-overlay/defaults'
+import type { CursorKeyframe } from '../../../src/types/cursor-overlay'
+
+const TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'recast-expr-eval-'))
+const RATE = 1000
+
+/**
+ * Evaluate an overlay expression with ffmpeg itself: `aevalsrc` runs the same
+ * evaluator, one sample per millisecond, so value[i] is the expression at
+ * t = i / RATE.
+ */
+function evaluate(expr: string, durationSec: number): number[] {
+  const out = path.join(TMP_DIR, `eval-${Math.random().toString(36).slice(2)}.raw`)
+  execFileSync('ffmpeg', [
+    '-v', 'error',
+    '-f', 'lavfi', '-i', `aevalsrc='${expr}':s=${RATE}:d=${durationSec}`,
+    '-f', 'f64le', '-c:a', 'pcm_f64le', '-y', out,
+  ], { stdio: 'pipe', maxBuffer: 64 * 1024 * 1024 })
+
+  const buf = fs.readFileSync(out)
+  fs.unlinkSync(out)
+  const values: number[] = []
+  for (let i = 0; i + 8 <= buf.length; i += 8) values.push(buf.readDoubleLE(i))
+  return values
+}
+
+const at = (values: number[], t: number) => values[Math.round(t * RATE)]!
+
+const viewport = { width: 1280, height: 720 }
+const srcRes = { width: 1280, height: 720 }
+
+describe('overlay expressions evaluated by ffmpeg', () => {
+  it('places the cursor at every phase of a two-keyframe trajectory', () => {
+    const keyframes: CursorKeyframe[] = [
+      { x: 100, y: 100, videoTimeSec: 2 },
+      { x: 500, y: 400, videoTimeSec: 5 },
+    ]
+    const { x } = buildOverlayExpressions(keyframes, resolveCursorOverlayConfig({}), viewport, srcRes)
+    const v = evaluate(x, 6)
+
+    expect(at(v, 1.5)).toBe(0)          // before the approach starts
+    expect(at(v, 1.75)).toBeCloseTo(60, 3)  // approach starts 40px short
+    expect(at(v, 1.875)).toBeCloseTo(80, 3) // eased halfway
+    expect(at(v, 2.0)).toBeCloseTo(100, 3)  // arrival
+    expect(at(v, 2.4)).toBeCloseTo(100, 3)  // held while visible
+    expect(at(v, 2.6)).toBe(0)          // past hideAfterMs
+    expect(at(v, 4.75)).toBeCloseTo(100, 3) // second approach starts at the old spot
+    expect(at(v, 5.0)).toBeCloseTo(500, 3)
+    expect(at(v, 5.4)).toBeCloseTo(500, 3)
+    expect(at(v, 5.6)).toBe(0)
+  })
+
+  it('lets a later movement win while visibility windows overlap', () => {
+    const config = resolveCursorOverlayConfig({ moveDurationMs: 500, hideAfterMs: 500 })
+    const keyframes: CursorKeyframe[] = [
+      { x: 100, y: 100, videoTimeSec: 2 },
+      { x: 200, y: 200, videoTimeSec: 2.2 },
+    ]
+    const { x } = buildOverlayExpressions(keyframes, config, viewport, srcRes)
+    const v = evaluate(x, 3.5)
+
+    expect(at(v, 1.5)).toBeCloseTo(60, 3)   // first approach
+    expect(at(v, 2.0)).toBeCloseTo(100, 3)  // first arrival, second approach starts
+    expect(at(v, 2.1)).toBeCloseTo(150, 3)  // eased halfway to the second target
+    expect(at(v, 2.2)).toBeCloseTo(200, 3)
+    expect(at(v, 2.4)).toBeCloseTo(200, 3)  // later keyframe wins over the first hold
+    expect(at(v, 2.71)).toBe(0)
+  })
+
+  it('scales viewport coordinates to the source resolution', () => {
+    const { x, y } = buildOverlayExpressions(
+      [{ x: 100, y: 200, videoTimeSec: 2 }],
+      resolveCursorOverlayConfig({}),
+      viewport,
+      { width: 1920, height: 1080 },
+    )
+    expect(at(evaluate(x, 3), 2.0)).toBeCloseTo(150, 3)
+    expect(at(evaluate(y, 3), 2.0)).toBeCloseTo(300, 3)
+  })
+
+  it('stays parseable for long screencasts with hundreds of keyframes', () => {
+    const keyframes: CursorKeyframe[] = Array.from({ length: 200 }, (_, i) => ({
+      x: 100 + i, y: 200 + i, videoTimeSec: 2 + i * 3,
+    }))
+    const { x, y } = buildOverlayExpressions(keyframes, resolveCursorOverlayConfig({}), viewport, srcRes)
+
+    // Sample around the 150th keyframe — beyond ffmpeg's expression nesting budget.
+    const vx = evaluate(x, 452)
+    expect(at(vx, 449)).toBeCloseTo(249, 3)
+    expect(at(vx, 451)).toBe(0)
+    const vy = evaluate(y, 452)
+    expect(at(vy, 449)).toBeCloseTo(349, 3)
+  })
+})

--- a/tests/unit/cursor-overlay/expression-eval.test.ts
+++ b/tests/unit/cursor-overlay/expression-eval.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -31,6 +31,10 @@ function evaluate(expr: string, durationSec: number): number[] {
 }
 
 const at = (values: number[], t: number) => values[Math.round(t * RATE)]!
+
+afterAll(() => {
+  fs.rmSync(TMP_DIR, { recursive: true, force: true })
+})
 
 const viewport = { width: 1280, height: 720 }
 const srcRes = { width: 1280, height: 720 }


### PR DESCRIPTION
A long screencast died in the cursor overlay stage with a filter parse error and a 0-byte output.

The trajectory expression nested one `if()` per keyframe, and ffmpeg's expression parser allows ~100 levels of nesting (`libavutil/eval.c`) — bisection measured the ceiling at **96 keyframes**. The screencast that hit this had 149.

Per-keyframe branches are now combined by a balanced bisection on movement start time, so nesting is log2(keyframes) — 8 levels at 149 keyframes. Equivalent to the chain because movement starts and window ends both grow in keyframe order.

New tests evaluate the built expressions with ffmpeg's own evaluator (`aevalsrc` → f64 samples): positions at every phase of a trajectory (approach, eased midpoint, arrival, hold, post-`hideAfterMs`), overlap priority, viewport scaling, and parsing at 200 keyframes.
