### PR TITLE
fix(ffmpeg): report ffmpeg's diagnostics instead of ENOBUFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **A failing ffmpeg now reports ffmpeg's own diagnostics** — exit status plus the head and tail of its output, rather than `spawnSync ffmpeg ENOBUFS` whenever that output outgrew Node's 1MB default buffer.
+
 ## 0.20.0 (2026-08-24)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- **A failing ffmpeg now reports ffmpeg's own diagnostics** — exit status plus the head and tail of its output, rather than `spawnSync ffmpeg ENOBUFS` whenever that output outgrew Node's 1MB default buffer. Every stage of the pipeline runs ffmpeg through the same wrapper.
+- **A failing ffmpeg now reports ffmpeg's own diagnostics** — exit status plus the head and tail of its output, rather than `spawnSync ffmpeg ENOBUFS` whenever that output outgrew Node's 1MB default buffer. Every ffmpeg call in the pipeline runs through the same wrapper, apart from the loudness-normalisation pair, which reads ffmpeg's output by design and already buffers 10MB.
 
 ## 0.20.0 (2026-08-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- **A failing ffmpeg now reports ffmpeg's own diagnostics** — exit status plus the head and tail of its output, rather than `spawnSync ffmpeg ENOBUFS` whenever that output outgrew Node's 1MB default buffer.
+- **A failing ffmpeg now reports ffmpeg's own diagnostics** — exit status plus the head and tail of its output, rather than `spawnSync ffmpeg ENOBUFS` whenever that output outgrew Node's 1MB default buffer. Every stage of the pipeline runs ffmpeg through the same wrapper.
 
 ## 0.20.0 (2026-08-24)
 

--- a/src/background-music/music-processor.ts
+++ b/src/background-music/music-processor.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path'
-import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 import type { ResolvedBackgroundMusicConfig } from './defaults.js'
 
 export interface VoiceoverSegment {
@@ -135,7 +135,7 @@ export function generateMusicTrack(
   inputArgs.push('-af', filters.join(','))
   inputArgs.push('-c:a', 'libmp3lame', '-q:a', '2', outputPath)
 
-  execFileSync('ffmpeg', inputArgs, { stdio: 'pipe' })
+  runFfmpeg(inputArgs)
 
   return outputPath
 }

--- a/src/click-effect/ripple-generator.ts
+++ b/src/click-effect/ripple-generator.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 
 export interface RippleArgs {
   color: string     // hex '#RRGGBB'
@@ -55,6 +55,6 @@ export function buildRippleArgs(opts: RippleArgs): string[] {
  */
 export function generateRippleClip(opts: RippleArgs): string {
   const args = buildRippleArgs(opts)
-  execFileSync('ffmpeg', args, { stdio: 'pipe' })
+  runFfmpeg(args)
   return opts.outputPath
 }

--- a/src/click-effect/sound-track.ts
+++ b/src/click-effect/sound-track.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 
 export interface ClickSoundInput {
   clicks: Array<{ videoTimeMs: number }>
@@ -62,13 +63,13 @@ export function generateClickSoundTrack(input: ClickSoundInput): string {
     filterComplex = parts.join(';')
   }
 
-  execFileSync('ffmpeg', [
+  runFfmpeg([
     '-y', '-i', input.soundPath,
     '-filter_complex', filterComplex,
     '-map', '[out]',
     '-c:a', 'libmp3lame', '-q:a', '2',
     input.outputPath,
-  ], { stdio: 'pipe' })
+  ])
 
   return input.outputPath
 }

--- a/src/interpolate/interpolator.ts
+++ b/src/interpolate/interpolator.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 import type { InterpolateConfig, InterpolateMode, InterpolateQuality } from '../types/interpolate.js'
 
 interface MinterpolateParams {
@@ -78,7 +79,7 @@ function probeSourceFps(inputPath: string): number {
 }
 
 function runSinglePass(inputPath: string, outputPath: string, filter: string): void {
-  execFileSync('ffmpeg', [
+  runFfmpeg([
     '-y',
     '-i', inputPath,
     '-vf', filter,
@@ -87,7 +88,7 @@ function runSinglePass(inputPath: string, outputPath: string, filter: string): v
     '-crf', '18',
     '-an',
     outputPath,
-  ], { stdio: 'pipe' })
+  ])
 }
 
 /**

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -24,6 +24,7 @@ import { filterRenderableSubtitles } from '../subtitles/renderable.js'
 import { interpolateVideo } from '../interpolate/interpolator.js'
 import { isSpeedClockAuthority } from '../speed/clock-authority.js'
 import { alignFreezeToFrame } from '../voiceover/frame-align.js'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 
 /**
  * Detect blank/white frames at the start of a video and return the timestamp
@@ -91,7 +92,7 @@ export interface RenderableTrace extends ParsedTrace {
 }
 
 export function ffmpeg(args: string[]): void {
-  execFileSync('ffmpeg', args, { stdio: 'pipe' })
+  runFfmpeg(args)
 }
 
 /**

--- a/src/render/screencast-assembler.ts
+++ b/src/render/screencast-assembler.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 import type { ScreencastFrame } from '../types/trace.js'
 
 const DEFAULT_TAIL_DURATION_SEC = 0.04
@@ -58,7 +58,7 @@ export async function assembleVideoFromScreencastFrames(opts: AssembleOptions): 
   // frame rate. The `fps` filter duplicates frames during idle pauses and
   // drops during bursts — preserving the visual cadence of the screencast.
   // 25fps matches Playwright's recordVideo default.
-  execFileSync('ffmpeg', [
+  runFfmpeg([
     '-y',
     '-f', 'concat', '-safe', '0', '-i', concatPath,
     // JPEG inputs come in yuvj420p (full range). Explicit `scale` with
@@ -70,7 +70,7 @@ export async function assembleVideoFromScreencastFrames(opts: AssembleOptions): 
     '-c:v', 'libx264', '-preset', 'fast', '-crf', '18',
     '-r', String(OUTPUT_FPS),
     outputPath,
-  ], { stdio: 'pipe' })
+  ])
 }
 
 /**

--- a/src/text-highlight/highlight-generator.ts
+++ b/src/text-highlight/highlight-generator.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 
 export interface HighlightClipArgs {
   /** Highlight color as hex '#RRGGBB' */
@@ -88,6 +88,6 @@ export function buildHighlightArgs(opts: HighlightClipArgs): string[] {
  */
 export function generateHighlightClip(opts: HighlightClipArgs): string {
   const args = buildHighlightArgs(opts)
-  execFileSync('ffmpeg', args, { stdio: 'pipe' })
+  runFfmpeg(args)
   return opts.outputPath
 }

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -23,3 +23,51 @@ export function assertFfmpegAvailable(): void {
     }
   }
 }
+
+/** ffmpeg repeats long filter expressions in its diagnostics, so allow room. */
+const MAX_FFMPEG_OUTPUT = 64 * 1024 * 1024
+/** Lines kept from each end of ffmpeg's output, and their max width. */
+const HEAD_LINES = 8
+const TAIL_LINES = 20
+const MAX_LINE_LENGTH = 240
+
+/**
+ * Run ffmpeg, raising an error that carries ffmpeg's own diagnostics.
+ *
+ * `execFileSync` defaults to a 1MB output buffer, and a filter parse error
+ * echoes the whole graph on every nesting level, so a big screencast failed
+ * with a bare `spawnSync ffmpeg ENOBUFS` and nothing else.
+ */
+export function runFfmpeg(args: string[]): void {
+  try {
+    execFileSync('ffmpeg', args, { stdio: 'pipe', maxBuffer: MAX_FFMPEG_OUTPUT })
+  } catch (error: unknown) {
+    throw new Error(describeFfmpegFailure(error), { cause: error })
+  }
+}
+
+function describeFfmpegFailure(error: unknown): string {
+  const err = error as NodeJS.ErrnoException & { status?: number | null; stderr?: Buffer | string }
+  if (err.code === 'ENOENT') {
+    return '"ffmpeg" is not installed or not on PATH.'
+  }
+
+  const status = err.status ?? null
+  const header = `ffmpeg failed${status === null ? '' : ` (exit ${status})`}${err.code ? ` [${err.code}]` : ''}`
+  const output = err.stderr?.toString() ?? ''
+  if (output.trim() === '') return `${header}: no output captured.`
+
+  const lines = output.split('\n').filter(line => line.trim() !== '')
+    .map(line => (line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)}…` : line))
+
+  // Parse errors report at the top, encoding errors at the bottom — keep both.
+  const kept = lines.length <= HEAD_LINES + TAIL_LINES
+    ? lines
+    : [
+      ...lines.slice(0, HEAD_LINES),
+      `… ${lines.length - HEAD_LINES - TAIL_LINES} line(s) omitted …`,
+      ...lines.slice(-TAIL_LINES),
+    ]
+
+  return `${header}:\n${kept.join('\n')}`
+}

--- a/src/voiceover/providers/qwen.ts
+++ b/src/voiceover/providers/qwen.ts
@@ -2,7 +2,8 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import * as crypto from 'node:crypto'
-import { execFileSync, spawnSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
+import { runFfmpeg } from '../../utils/ffmpeg.js'
 import { fileURLToPath } from 'node:url'
 import type { TtsProvider, TtsOptions, AudioSegment } from '../../types/voiceover.js'
 import { hashValues, hashFile } from './util/hash.js'
@@ -141,13 +142,13 @@ function ensureDir(dir: string): void {
 
 function convertWavToMp3(wavPath: string, mp3Path: string): void {
   ensureDir(path.dirname(mp3Path))
-  execFileSync('ffmpeg', [
+  runFfmpeg([
     '-y', '-hide_banner', '-loglevel', 'error',
     '-i', wavPath,
     '-ac', '1',
     '-c:a', 'libmp3lame', '-b:a', '192k',
     mp3Path,
-  ], { stdio: 'pipe' })
+  ])
 }
 
 export function QwenTtsProvider(config: QwenTtsProviderConfig): TtsProvider {

--- a/src/voiceover/voiceover-processor.ts
+++ b/src/voiceover/voiceover-processor.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { execFileSync } from 'node:child_process'
+import { runFfmpeg } from '../utils/ffmpeg.js'
 import { probeAudioFormat, planAudioConcat } from './audio-format.js'
 import type { SubtitledTrace } from '../types/subtitle.js'
 import type {
@@ -26,13 +27,13 @@ function getAudioDurationMs(filePath: string): number {
 
 function generateSilence(durationMs: number, outputPath: string, sampleRate = 24000, channels = 1): void {
   const durationSec = Math.max(0.01, durationMs / 1000)
-  execFileSync('ffmpeg', [
+  runFfmpeg([
     '-y', '-f', 'lavfi',
     '-i', `anullsrc=r=${sampleRate}:cl=${channels}c`,
     '-t', String(durationSec),
     '-c:a', 'libmp3lame', '-q:a', '9',
     outputPath,
-  ], { stdio: 'pipe' })
+  ])
 }
 
 /** Resolve normalize option to a concrete config or `null` (disabled). */
@@ -222,12 +223,12 @@ export async function generateVoiceover(
     if (plan.normalise) {
       console.log(`  Voiceover: segment formats differ — normalising to ${plan.sampleRate}Hz/${plan.channels}ch`)
     }
-    execFileSync('ffmpeg', [
+    runFfmpeg([
       '-y', '-f', 'concat', '-safe', '0',
       '-i', concatList,
       ...codecArgs,
       audioTrackPath,
-    ], { stdio: 'pipe' })
+    ])
   }
 
   const totalDurationMs = segmentFiles.length > 0

--- a/tests/unit/render/ffmpeg-errors.test.ts
+++ b/tests/unit/render/ffmpeg-errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { ffmpeg } from '../../../src/render/renderer'
+
+/** ffmpeg echoes the offending expression on every parse error, so a big
+ *  filter produces megabytes of stderr — past Node's default 1MB maxBuffer. */
+function hugeBogusExpression(levels: number): string {
+  let expr = '0'
+  for (let i = 0; i < levels; i++) {
+    expr = `if(between(t\\,${i}.0000\\,${i + 5}.0000)\\,st(0\\,(t-${i}.0000)/0.2500)\;` +
+      `${1000 + i}+(50)*(3*ld(0)*ld(0)-2*ld(0)*ld(0)*ld(0))\\,${expr})`
+  }
+  return expr
+}
+
+describe('ffmpeg()', () => {
+  it('reports ffmpeg\'s own diagnostics when it floods stderr', () => {
+    let message = ''
+    try {
+      ffmpeg([
+        '-y', '-f', 'lavfi', '-i', 'color=c=black:s=64x64:r=5:d=1',
+        '-vf', `drawtext=text=x:fontsize=10:y=0:x='${hugeBogusExpression(200)}'`,
+        '-f', 'null', '-',
+      ])
+      throw new Error('expected ffmpeg() to throw')
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).not.toContain('ENOBUFS')
+    expect(message).toContain('ffmpeg')
+    expect(message).toContain("Missing ')' or too many args")
+  })
+
+  it('reports the exit status and the tail of ffmpeg output for ordinary failures', () => {
+    expect(() => ffmpeg(['-y', '-i', '/nonexistent/input.mp4', '-f', 'null', '-']))
+      .toThrow(/No such file or directory/)
+  })
+})

--- a/tests/unit/render/ffmpeg-errors.test.ts
+++ b/tests/unit/render/ffmpeg-errors.test.ts
@@ -18,7 +18,7 @@ describe('ffmpeg()', () => {
     try {
       ffmpeg([
         '-y', '-f', 'lavfi', '-i', 'color=c=black:s=64x64:r=5:d=1',
-        '-vf', `drawtext=text=x:fontsize=10:y=0:x='${hugeBogusExpression(200)}'`,
+        '-vf', `drawbox=x='${hugeBogusExpression(200)}':y=0:w=10:h=10:color=red`,
         '-f', 'null', '-',
       ])
       throw new Error('expected ffmpeg() to throw')

--- a/tests/unit/render/ffmpeg-errors.test.ts
+++ b/tests/unit/render/ffmpeg-errors.test.ts
@@ -27,8 +27,17 @@ describe('ffmpeg()', () => {
     }
 
     expect(message).not.toContain('ENOBUFS')
-    expect(message).toContain('ffmpeg')
     expect(message).toContain("Missing ')' or too many args")
+
+    const lines = message.split('\n')
+    // Exit status, both ends of the output, and a marker for what was dropped.
+    expect(lines[0]).toMatch(/^ffmpeg failed \(exit \d+\)/)
+    expect(message).toContain('ffmpeg version')
+    expect(message).toContain('Conversion failed')
+    expect(message).toMatch(/… \d+ line\(s\) omitted …/)
+    // Every kept line is capped, so one echoed 40KB expression cannot bury it.
+    expect(Math.max(...lines.map((line) => line.length))).toBeLessThanOrEqual(241)
+    expect(lines.length).toBeLessThanOrEqual(30)
   })
 
   it('reports the exit status and the tail of ffmpeg output for ordinary failures', () => {


### PR DESCRIPTION
A filter parse error makes ffmpeg echo the whole graph on every nesting level, so a big screencast produced ~1.1 MB of stderr — past `execFileSync`'s default 1 MB buffer. Node then aborted with `spawnSync ffmpeg ENOBUFS`, SIGTERM'd ffmpeg (which exits 255) and threw the real diagnostics away. The actual error was invisible.

`runFfmpeg()` keeps a 64 MB buffer and raises an error carrying the exit status plus the head and tail of ffmpeg's output, with lines length-capped.

Test asserts the thrown message contains ffmpeg's own diagnostic and not `ENOBUFS`, for a command that floods stderr.
